### PR TITLE
feat: Internal User/Courier API + 검색 필터 + HubProvider Feign + Courier 도메인 완성

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,4 @@ out/
 .vscode/
 .env*
 kafka.server.truststore.jks
+ignoredocs/

--- a/README.md
+++ b/README.md
@@ -1,213 +1,469 @@
 # Loopang User Service
 
-loopang MSA 프로젝트의 유저 + 배송담당자 도메인 서비스.
+loopang MSA 프로젝트의 **유저 + 배송담당자(Courier) 도메인** 서비스.
+회원가입/인증부터 배송담당자 등록·배정 후보 조회까지 단일 source of truth로 관리한다.
 
-## 기술 스택
+---
 
-- Java 21, Spring Boot 3.5.13, Spring Cloud 2025.0.1
-- Spring MVC (Servlet 기반)
-- 공통 모듈: `com.loopang:common:0.0.4-SNAPSHOT`
-- PostgreSQL 17, JPA + QueryDSL
-- Keycloak 24.0.0 (OAuth2 Resource Server, Admin Client)
-- Redis (세션/캐싱)
-- Eureka Client + Config Server
-- Lombok, Gradle
-- server.port: Config Server에서 관리
+## 🏷️ 기술 스택
 
-## 도메인 범위
+| 분류 | 사용 기술 |
+|---|---|
+| Language / Framework | Java 21, Spring Boot 3.5.13, Spring Cloud 2025.0.1 |
+| Web | Spring MVC (Servlet 기반) |
+| 공통 모듈 | `com.loopang:common:0.0.5-SNAPSHOT` (GitHub Packages) |
+| DB / ORM | PostgreSQL 17, JPA, QueryDSL 5.1 |
+| 인증 | Keycloak 24.0.0 (OAuth2 Resource Server, Admin Client) |
+| 캐시 | Spring Data Redis |
+| 디스커버리 / 설정 | Eureka Client, Spring Cloud Config |
+| 서비스 간 통신 | Spring Cloud OpenFeign (hub-service 호출) |
+| 빌드 | Gradle |
+| 포트 | Config Server에서 관리 |
 
-- **유저 관리** (회원가입, 로그인/로그아웃, 조회, 수정, 삭제) — `p_user`
-- **배송담당자 관리** — `p_courier`
-- **인증** — Keycloak 연동 (토큰 발급, 회원가입, 탈퇴)
+---
 
-## API 엔드포인트
+## 🎯 도메인 범위
 
-### 인증
+| 도메인 | 책임 |
+|---|---|
+| **User** | 신원, 권한(role), 소속 허브(`HubInfo` Embedded), 회원가입/로그인/로그아웃/CRUD |
+| **Courier** | 배송담당자 — User에 1:1 매핑, 운영 정보(`deliveryChargeType`, `deliveryTurn`), 배정 후보 조회 |
+| **인증** | Keycloak 연동 (토큰 발급, 회원가입, 탈퇴) |
 
-| 메서드 | URL | 설명 | 인증 | 권한 | 상태 |
-|---|---|---|---|---|---|
-| POST | `/api/users` | 회원가입 (Keycloak + DB) | 불필요 | 전체 (MASTER 제외) | ✅ |
-| POST | `/api/users/login` | 로그인 (JWT 토큰 발급) | 불필요 | 전체 | ✅ |
-| POST | `/api/users/logout` | 로그아웃 (토큰 무효화) | 불필요 | 전체 | ✅ |
+> **Courier owner는 user-service**입니다. delivery-service는 자체 Courier 엔티티 없이 본 서비스의 Internal API를 Feign으로 호출해 후보를 받아 배정합니다.
 
-### 유저
+---
 
-| 메서드 | URL | 설명 | 인증 | 권한 | 상태 |
-|---|---|---|---|---|---|
-| GET | `/api/users/me` | 현재 유저 정보 | X-User-UUID | 본인 | ✅ |
-| GET | `/api/users/{userId}` | 유저 단건 조회 | X-User-Role | MASTER | ✅ |
-| GET | `/api/users` | 유저 목록 조회 (페이징) | X-User-Role | MASTER | ✅ |
-| PATCH | `/api/users/{userId}` | 유저 수정 | X-User-Role | MASTER | ✅ |
-| DELETE | `/api/users/{userId}` | 유저 삭제 (소프트) | X-User-UUID + X-User-Role | MASTER | ✅ |
+## 📡 API 엔드포인트
 
-### 배송담당자 (구현 예정)
+### 🔐 인증
 
-| 메서드 | URL | 설명 | 인증 | 상태 |
+| 메서드 | URL | 설명 | 인증 | 권한 |
 |---|---|---|---|---|
-| GET | `/api/couriers` | 배송담당자 목록 | 필요 | ⬜ |
-| PUT | `/api/couriers/{courierId}` | 배송순번 변경 | MASTER/HUB | ⬜ |
+| POST | `/api/users` | 회원가입 (Keycloak + DB) | 불필요 | 전체 (MASTER 제외) |
+| POST | `/api/users/login` | 로그인 (JWT 토큰 발급) | 불필요 | 전체 |
+| POST | `/api/users/logout` | 로그아웃 (refresh token 무효화) | 불필요 | 전체 |
 
-## 보안
+### 👤 유저 (외부 — `/api/users/**`)
 
-### 권한 체크
-- MASTER 전용 API: Controller에서 `@RequestHeader("X-User-Role")` + `checkMaster()` 검증
-- 회원가입 시 MASTER 권한 직접 지정 차단 (`ForbiddenException`)
-- 회원가입 후 `approved=false` → 관리자 승인 전까지 서비스 사용 제한
+| 메서드 | URL | 설명 | 권한 |
+|---|---|---|---|
+| GET | `/api/users/me` | 내 정보 (X-User-UUID 헤더) | 본인 |
+| GET | `/api/users/{userId}` | 단건 조회 | MASTER |
+| GET | `/api/users?role=&hubId=&page=&size=` | 페이지네이션 + role/hubId 필터 | MASTER |
+| PATCH | `/api/users/{userId}` | 수정 | MASTER |
+| DELETE | `/api/users/{userId}` | 소프트 삭제 | MASTER |
 
-### 보상 트랜잭션
-- 회원가입: Keycloak 등록 성공 후 DB 저장 실패 시 → Keycloak 유저 롤백 (`identityProvider.withdraw`)
-- 롤백 실패 시 원인 예외 보존 (별도 try-catch)
+### 👤 유저 (내부 — `/internal/users/**`)
 
-### 에러 메시지
-- 이메일/SlackID 중복 에러에 원문 미노출 (개인정보 보호)
+| 메서드 | URL | 설명 |
+|---|---|---|
+| GET | `/internal/users/{userId}` | 단건 조회 (권한 검증 없음) |
+| GET | `/internal/users?role=&hubId=` | 리스트 조회 (페이지네이션 X, `enabled=true` 필터) |
 
-## 테이블 구조
+> ⚠️ **`/internal/**` 경로는 gateway 라우팅에서 제외되어 있습니다.** 서비스 간 Feign 호출은 Eureka 디스커버리로 user-service 인스턴스에 직접 도달하므로 gateway 우회. 외부 클라이언트는 접근 불가.
 
-### p_user (유저)
+### 🚚 배송담당자 (외부 — `/api/couriers/**`)
+
+| 메서드 | URL | 설명 | 권한 |
+|---|---|---|---|
+| POST | `/api/couriers` | 등록 (`{ userId, deliveryChargeType }`) | MASTER |
+| GET | `/api/couriers/{courierId}` | 단건 조회 | MASTER |
+| GET | `/api/couriers?hubId=&type=&page=&size=` | 페이지네이션 + 필터 | MASTER |
+| PATCH | `/api/couriers/{courierId}` | 타입 변경 (HUB ↔ COMPANY) | MASTER |
+| DELETE | `/api/couriers/{courierId}` | 소프트 삭제 | MASTER |
+
+### 🚚 배송담당자 (내부 — `/internal/couriers/**`)
+
+| 메서드 | URL | 설명 |
+|---|---|---|
+| GET | `/internal/couriers/{courierId}` | 단건 조회 (배송 알림용) |
+| GET | `/internal/couriers?hubId=&type=` | **라운드로빈 후보 리스트** (`deliveryTurn` ASC, `enabled=true`만) |
+
+---
+
+## 🏗️ 도메인 / 데이터 모델
+
+### `p_user` — 유저
 
 | 컬럼 | 타입 | 제약 | 설명 |
 |---|---|---|---|
-| id | UUID | PK | 유저ID (Keycloak sub) |
+| id | UUID | PK | Keycloak `sub` |
 | email | VARCHAR(50) | NOT NULL | 이메일 |
 | name | VARCHAR(50) | NOT NULL | 이름 |
-| slack_id | VARCHAR(100) | NOT NULL | 슬랙ID |
-| role | VARCHAR(10) | NOT NULL | 권한 (MASTER/HUB/DELIVERY/COMPANY/PENDING) |
-| hub_id | UUID | NOT NULL | 소속허브ID |
-| hub_name | VARCHAR(50) | NOT NULL | 소속허브명 |
-| company_id | UUID | NULL | 업체ID (업체 관련 사용자만) |
-| company_name | VARCHAR(100) | NULL | 업체명 |
-| approved | BOOLEAN | | 승인 여부 |
-| version | INT | | 낙관적 락 (@Version) |
-| + BaseUserEntity (createdAt/By, updatedAt/By, deletedAt/By) |
+| slack_id | VARCHAR(100) | NOT NULL | 슬랙 ID |
+| role | VARCHAR(10) | NOT NULL | MASTER / HUB / DELIVERY / COMPANY / PENDING |
+| hub_id | UUID | NOT NULL | `HubInfo.hubId` (소속 허브) |
+| hub_name | VARCHAR(50) | NOT NULL | `HubInfo.hubName` |
+| company_id | UUID | NULL | `CompanyInfo.companyId` (업체 사용자만) |
+| company_name | VARCHAR(100) | NULL | `CompanyInfo.companyName` |
+| approved | BOOLEAN | | 관리자 승인 여부 |
+| version | INT | | 낙관적 락 (`@Version`) |
+| + BaseUserEntity | | | createdAt/By, updatedAt/By, deletedAt/By |
 
-### p_courier (배송담당자)
+### `p_courier` — 배송담당자
 
 | 컬럼 | 타입 | 제약 | 설명 |
 |---|---|---|---|
-| courier_id | UUID | PK | 배송담당자ID |
-| user_id | UUID | FK, NOT NULL | 유저ID |
+| courier_id | UUID | PK | |
+| user_id | UUID | FK → `p_user.id`, NOT NULL | 1:1 매핑 |
+| **hub_id** | UUID | NOT NULL | 등록 시점 user 소속 허브 (denormalize) |
+| **hub_name** | VARCHAR(50) | NOT NULL | 등록 시점 hub-service 응답값 |
 | delivery_charge_type | VARCHAR(10) | NOT NULL | HUB / COMPANY |
-| delivery_turn | INT | NOT NULL | 배송순번 |
-| version | INT | | 낙관적 락 (@Version) |
-| + BaseUserEntity |
+| delivery_turn | INT | NOT NULL | 배송 순번 (라운드로빈 정렬 키) |
+| version | INT | | 낙관적 락 |
+| + BaseUserEntity | | | |
+
+**유니크 제약: `uk_courier_hub_type_turn` (hub_id, delivery_charge_type, delivery_turn)**
+→ 동시 등록 시 race condition으로 같은 turn이 중복 할당되는 것을 DB 레벨에서 차단.
 
 ### 엔티티 특징
-- `@SQLRestriction("deleted_at IS NULL")` — 소프트 삭제된 데이터 조회 시 자동 제외
+- `@SQLRestriction("deleted_at IS NULL")` — soft-deleted 자동 제외
 - `@Version` — 낙관적 락 (동시 수정 방지)
-- `BaseUserEntity` 상속 — createdAt/By, updatedAt/By, deletedAt/By 자동 관리
-- `HubInfo`, `CompanyInfo` — @Embeddable VO (Provider 연동 후 검증 예정)
+- `BaseUserEntity` 상속 — 감사 필드 자동 관리
+- `HubInfo` / `CompanyInfo` — `@Embeddable` VO
 
-### 예외 처리
+---
 
-| 클래스 | 상위 예외 | 설명 |
+## 🔄 핵심 흐름
+
+### 회원가입 (POST /api/users)
+
+```
+1. Request 검증 (이메일/슬랙ID 중복, MASTER 권한 차단)
+2. HubProvider.get(hubId)
+   ├─ FeignException.NotFound → NotFoundException(404)
+   ├─ FeignException(5xx 등) → InternalServerException(500)
+   └─ 응답 hubId가 요청 hubId와 일치하는지 검증
+3. Keycloak에 user 등록 (identityProvider.register)
+4. p_user INSERT (HubInfo, CompanyInfo 포함)
+   ⚠️ DB 저장 실패 시 보상 트랜잭션: identityProvider.withdraw로 Keycloak 롤백
+5. SignupResponseDto 반환
+```
+
+### 배송담당자 등록 (POST /api/couriers)
+
+```
+1. user 조회 + 검증 (role=DELIVERY, enabled=true, hubInfo 필수)
+2. 중복 등록 확인 (findByUser_Id)
+3. HubProvider.get(user.hubInfo.hubId)
+   → 회원가입 시점 이후 허브명이 바뀌었을 수 있으므로 hub-service에서 최신값 fetch
+4. saveWithTurnRetry() — 동시성 방어
+   ├─ findMaxDeliveryTurn(hubId, type) + 1
+   ├─ Courier.register(user, hubInfo, type, nextTurn) → save
+   └─ DataIntegrityViolationException catch 시 max+1 다시 읽고 재시도 (최대 5회)
+5. 5회 모두 실패 시 InternalServerException
+```
+
+### 라운드로빈 후보 조회 (GET /internal/couriers)
+
+```
+delivery-service Feign 호출
+  ↓
+1. findAllByHubInfo_HubIdAndTypeOrderByDeliveryTurnAsc(hubId, type)
+2. 소속 user.enabled=true 필터 (배정 부적합 제외)
+3. CourierResponseDto 리스트 반환
+  ↓
+delivery-service: 라운드로빈으로 1명 선정 → 배송 레코드에 assignedCourierId 저장
+```
+
+---
+
+## 🔌 외부 서비스 연동
+
+### Feign Client — `HubFeignClient` → hub-service
+
+| 호출 | 용도 |
+|---|---|
+| `GET /api/hubs/{hubId}` | 회원가입/수정/Courier 등록 시 최신 `hubName` 조회 |
+
+**오류 처리 (`HubProviderImpl`):**
+| FeignException | 변환 | HTTP |
 |---|---|---|
-| `UserErrorCode` | ErrorCodeSpec | 에러 코드 enum |
-| `UserNotFoundException` | NotFoundException (404) | 사용자를 찾을 수 없습니다 |
-| `UserEmailDuplicateException` | ConflictException (409) | 이미 사용중인 이메일입니다 |
-| `UserSlackIdDuplicateException` | ConflictException (409) | 이미 사용중인 SlackID입니다 |
+| `FeignException.NotFound` | `NotFoundException` | 404 |
+| 그 외 (`5xx`, 타임아웃, 연결 실패) | `InternalServerException` | 500 |
+| 응답 직렬화 실패 등 | `InternalServerException` | 500 |
+| 응답 hubId ≠ 요청 hubId | `InternalServerException` | 500 |
 
-## 클린 아키텍처
+### Keycloak — `KeycloakIdentityProvider`
 
-```text
+| 메서드 | 용도 |
+|---|---|
+| `register(email, password)` | 사용자 등록 |
+| `login(email, password)` | JWT 토큰 발급 |
+| `logout(refreshToken)` | refresh token 무효화 |
+| `withdraw(userId)` | 사용자 탈퇴 (보상 트랜잭션 포함) |
+| `changePassword(userId, newPassword)` | 비밀번호 변경 |
+
+---
+
+## 🛡️ 보안
+
+### 권한 체크 (현재)
+- 외부 API: Controller에서 `@RequestHeader("X-User-Role") + checkMaster()`
+- Keycloak JWT는 Gateway에서 검증 후 헤더로 전파
+- `/internal/**` 경로는 권한 검증 없음 — gateway 라우팅에서 제외해 외부 노출 차단
+
+### 향후 (common Phase 4)
+- `LoginFilter` + `SecurityContext` + `SecurityUtil` 또는 `@PreAuthorize` 기반 전환
+- 전 서비스 일괄 마이그레이션
+
+### 보상 트랜잭션
+회원가입 시 Keycloak 등록 성공 후 DB 저장 실패 → Keycloak 사용자 롤백
+- 롤백 실패 시 원인 예외 보존 (별도 try-catch, 로그 기록)
+
+### 회원가입 정책
+- MASTER 권한 직접 지정 차단 (`ForbiddenException`)
+- `approved=false` 기본값 → 관리자 승인 전까지 서비스 사용 제한
+- 이메일/SlackID 중복 시 원문 미노출 (개인정보 보호)
+
+---
+
+## 🧱 클린 아키텍처
+
+```
 com.loopang.userservice
 ├── application/
 │   └── service/
-│       └── UserService.java            # signup, login, logout, CRUD
+│       ├── UserService.java                    # signup, login, logout, CRUD, internal 조회
+│       └── CourierService.java                 # register (turn 재시도), CRUD, findCandidatesForAssignment
+│
 ├── domain/
 │   ├── entity/
-│   │   ├── User.java                   # @SQLRestriction, @Version
-│   │   └── Courier.java
+│   │   ├── User.java                           # @SQLRestriction, @Version, HubInfo/CompanyInfo @Embedded
+│   │   └── Courier.java                        # @OneToOne User, @Embedded HubInfo, unique constraint
 │   ├── exception/
-│   │   ├── UserErrorCode.java
-│   │   ├── UserNotFoundException.java
-│   │   ├── UserEmailDuplicateException.java
-│   │   └── UserSlackIdDuplicateException.java
+│   │   ├── UserNotFoundException.java          # 404
+│   │   ├── UserEmailDuplicateException.java    # 409
+│   │   ├── UserSlackIdDuplicateException.java  # 409
+│   │   ├── CourierNotFoundException.java       # 404
+│   │   └── CourierDuplicateException.java      # 409
 │   ├── repository/
-│   │   ├── UserRepository.java         # 인터페이스
+│   │   ├── UserRepository.java                 # 인터페이스 — 신호 declarations만
 │   │   └── CourierRepository.java
-│   ├── service/
-│   │   ├── IdentityProvider.java       # Keycloak 연동 인터페이스
+│   ├── service/                                # 외부 의존성 인터페이스 (DIP)
+│   │   ├── IdentityProvider.java               # Keycloak 추상화
 │   │   ├── RoleCheck.java
-│   │   ├── HubProvider.java
-│   │   ├── CompanyProvider.java
-│   │   └── dto/
-│   │       └── TokenData.java          # 도메인 레벨 토큰 DTO
+│   │   ├── HubProvider.java                    # hub-service Feign 추상화
+│   │   ├── CompanyProvider.java                # company-service Feign 추상화 (TODO)
+│   │   └── dto/TokenData.java
 │   └── vo/
-│       ├── UserType.java               # MASTER, HUB, DELIVERY, COMPANY, PENDING
-│       ├── DeliveryChargeType.java
-│       ├── HubInfo.java                # @Embeddable
-│       └── CompanyInfo.java
+│       ├── UserType.java                       # MASTER, HUB, DELIVERY, COMPANY, PENDING
+│       ├── DeliveryChargeType.java             # HUB, COMPANY
+│       ├── HubInfo.java                        # @Embeddable (hub_id, hub_name)
+│       └── CompanyInfo.java                    # @Embeddable (company_id, company_name)
+│
 ├── infrastructure/
 │   ├── repository/
-│   │   ├── JpaUserRepository.java
-│   │   └── JpaCourierRepository.java
-│   └── keycloak/
-│       ├── KeycloakIdentityProvider.java  # register, login, logout, withdraw, changePassword
-│       └── KeycloakProperties.java        # @ConfigurationProperties + @Validated
-├── presentation/
-│   ├── controller/
-│   │   └── UserController.java         # 인증 + CRUD + 권한 체크
-│   └── dto/
-│       ├── SignupRequestDto.java
-│       ├── LoginRequestDto.java
-│       ├── LogoutRequestDto.java
-│       ├── UserUpdateRequestDto.java
-│       └── response/
-│           ├── SignupResponseDto.java
-│           ├── TokenResponseDto.java
-│           └── UserResponseDto.java
-└── config/
+│   │   ├── JpaUserRepository.java              # JpaRepository + UserRepository
+│   │   └── JpaCourierRepository.java           # @Query findMaxDeliveryTurn
+│   ├── keycloak/
+│   │   ├── KeycloakIdentityProvider.java
+│   │   └── KeycloakProperties.java
+│   └── feign/
+│       ├── HubFeignClient.java                 # @FeignClient(name = "hub-service")
+│       ├── HubProviderImpl.java                # FeignException 분리 처리
+│       └── dto/HubData.java                    # 응답 record
+│
+└── presentation/
+    ├── controller/
+    │   ├── UserController.java                 # /api/users (외부)
+    │   ├── InternalUserController.java         # /internal/users (내부 Feign용)
+    │   ├── CourierController.java              # /api/couriers (외부)
+    │   └── InternalCourierController.java      # /internal/couriers (내부 Feign용)
+    └── dto/
+        ├── SignupRequestDto.java
+        ├── LoginRequestDto.java
+        ├── LogoutRequestDto.java
+        ├── UserUpdateRequestDto.java
+        ├── CourierCreateRequestDto.java
+        ├── CourierUpdateRequestDto.java
+        └── response/
+            ├── SignupResponseDto.java
+            ├── TokenResponseDto.java
+            ├── UserResponseDto.java
+            └── CourierResponseDto.java
 ```
 
-## 로컬 실행
+**의존성 방향:** `presentation → application → domain ← infrastructure`
+
+---
+
+## ⚠️ 동시성 처리
+
+### `deliveryTurn` race condition
+
+**문제:** `MAX(deliveryTurn) + 1` 방식은 두 트랜잭션이 동시에 같은 max를 읽으면 같은 turn을 할당함 → 라운드로빈 순서 깨짐.
+
+**해결:**
+1. **DB 유니크 제약** `(hub_id, delivery_charge_type, delivery_turn)` — 중복을 원자적으로 차단
+2. **재시도 루프** `saveWithTurnRetry()` — `DataIntegrityViolationException` catch 시 max를 다시 읽고 재시도, 최대 5회
+3. 5회 모두 실패 시 `InternalServerException`
+
+```java
+private Courier saveWithTurnRetry(User user, HubInfo hubInfo, DeliveryChargeType type, ...) {
+    for (int attempt = 1; attempt <= MAX_TURN_RETRY; attempt++) {
+        int nextTurn = courierRepository.findMaxDeliveryTurn(hubInfo.getHubId(), type).orElse(0) + 1;
+        try {
+            return courierRepository.save(Courier.register(user, hubInfo, type, nextTurn));
+        } catch (DataIntegrityViolationException e) {
+            if (attempt == MAX_TURN_RETRY) {
+                throw new InternalServerException("배송담당자 등록 중 동시성 충돌이 반복되었습니다.");
+            }
+        }
+    }
+    throw new InternalServerException("배송담당자 등록에 실패했습니다.");
+}
+```
+
+대안인 `SELECT ... FOR UPDATE` 잠금은 핫스팟에서 처리량이 떨어져 채택하지 않았습니다. 충돌이 드문 환경(MASTER 수동 등록)에서 재시도 비용이 거의 0입니다.
+
+---
+
+## 📑 예외 정책
+
+| 클래스 | 상위 | HTTP | 설명 |
+|---|---|---|---|
+| `UserNotFoundException` | NotFoundException | 404 | 사용자를 찾을 수 없음 |
+| `UserEmailDuplicateException` | ConflictException | 409 | 이메일 중복 |
+| `UserSlackIdDuplicateException` | ConflictException | 409 | 슬랙 ID 중복 |
+| `CourierNotFoundException` | NotFoundException | 404 | 배송담당자를 찾을 수 없음 |
+| `CourierDuplicateException` | ConflictException | 409 | 이미 등록된 배송담당자 |
+| `BadRequestException` (common) | - | 400 | 도메인 검증 실패 (role, enabled, hubInfo) |
+| `ForbiddenException` (common) | - | 403 | MASTER 권한 필요 |
+| `InternalServerException` (common) | - | 500 | 동시성 충돌 한도 초과, hub-service 원격 장애 |
+
+전역 처리는 common의 `GlobalExceptionAdvice`가 담당.
+
+---
+
+## 🏃 로컬 실행
 
 ### 사전 조건
-- Eureka Server (18761)
-- Config Server (18888)
-- PostgreSQL Docker
-- Keycloak (13300)
+- Eureka Server (`18761`)
+- Config Server (`18888`)
+- PostgreSQL (Docker, `5432` 또는 `5435`)
+- hub-service — `HubProvider` Feign 호출 대상
+- Keycloak (`13300`) — 회원가입/로그인 흐름 검증 시
+- (선택) Gateway (`18080`) — 외부 API 통합 테스트 시
 
-### 환경변수 (IntelliJ Run Configuration)
+### 환경 변수 (IntelliJ Run Configuration)
 ```text
-DB_URL=localhost:5432/user;DB_USERNAME=postgres;DB_PASSWORD=본인비밀번호;KEYCLOAK_CLIENT_SECRET=본인시크릿
+DB_URL=localhost:5432/user
+DB_USERNAME=postgres
+DB_PASSWORD=본인비밀번호
+KEYCLOAK_CLIENT_SECRET=본인시크릿
+EUREKA_SERVER_URL=http://localhost:18761/eureka
 ```
 
-### Keycloak 로컬 실행
+### Keycloak 로컬 컨테이너
 ```bash
-docker run -d --name keycloak -p 13300:13300 -e KEYCLOAK_ADMIN=admin -e KEYCLOAK_ADMIN_PASSWORD=admin quay.io/keycloak/keycloak:24.0.0 start-dev --http-port=13300 --http-enabled=true --hostname-strict=false
+docker run -d --name keycloak \
+  -p 13300:13300 \
+  -e KEYCLOAK_ADMIN=admin \
+  -e KEYCLOAK_ADMIN_PASSWORD=admin \
+  quay.io/keycloak/keycloak:24.0.0 \
+  start-dev --http-port=13300 --http-enabled=true --hostname-strict=false
 
 # SSL 끄기 (master + my-realm)
-docker exec -it keycloak /opt/keycloak/bin/kcadm.sh config credentials --server http://localhost:13300 --realm master --user admin --password admin
+docker exec -it keycloak /opt/keycloak/bin/kcadm.sh config credentials \
+  --server http://localhost:13300 --realm master --user admin --password admin
 docker exec -it keycloak /opt/keycloak/bin/kcadm.sh update realms/master -s sslRequired=NONE
-docker exec -it keycloak /opt/keycloak/bin/kcadm.sh update realms/my-realm -s sslRequired=NONE --server http://localhost:13300 --realm master --user admin --password admin
+docker exec -it keycloak /opt/keycloak/bin/kcadm.sh update realms/my-realm -s sslRequired=NONE
 ```
 
-### Keycloak 설정
-- 관리 콘솔: `http://localhost:13300` (admin/admin)
+- 관리 콘솔: http://localhost:13300 (admin/admin)
 - Realm: `my-realm`
-- Client: `loopang-client` (Client authentication: On, Direct Access Grants: On)
+- Client: `loopang-client` (Client authentication: ON, Direct Access Grants: ON)
 
-## 구현 현황
+### 통합 테스트 시나리오 (Courier 도메인 검증)
 
-### 완료
-- [x] User/Courier 엔티티 (@SQLRestriction, @Version, BaseUserEntity)
+```bash
+# 1) hub-service에서 hubId 하나 받기
+curl http://localhost:18100/api/hubs?size=1
+
+# 2) 테스트 user 직접 INSERT (Keycloak 우회)
+docker exec -it postgres-hub psql -U postgres -d user -c "
+INSERT INTO p_user (id, version, email, name, slack_id, role, hub_id, hub_name, approved, created_at)
+VALUES (gen_random_uuid(), 0, 'test@loopang.site', '테스트', 'U_T1', 'DELIVERY',
+        'HUB_ID_여기에', '서울특별시 센터', true, NOW());
+SELECT id FROM p_user WHERE email = 'test@loopang.site';
+"
+
+# 3) Courier 등록
+curl -X POST http://localhost:18181/api/couriers \
+  -H "Content-Type: application/json" \
+  -H "X-User-Role: ROLE_MASTER" \
+  -d '{ "userId": "USER_ID_여기에", "deliveryChargeType": "HUB" }'
+
+# 4) 라운드로빈 후보 조회 (delivery-service가 호출하는 흐름)
+curl "http://localhost:18181/internal/couriers?hubId=HUB_ID_여기에&type=HUB"
+```
+
+기대 결과:
+- `hubName`이 `"서울특별시 센터"`로 정상 채워짐 (HubProvider Feign 검증)
+- `deliveryTurn: 1` 자동 할당
+- 두 번째 등록 시 `deliveryTurn: 2`
+
+---
+
+## 📋 구현 진행 상황
+
+### ✅ 완료
+- [x] User 엔티티 (`@SQLRestriction`, `@Version`, `BaseUserEntity`, `HubInfo` / `CompanyInfo` `@Embeddable`)
+- [x] Courier 엔티티 (`@OneToOne` User, `@Embedded` HubInfo, 유니크 제약, 정적 팩토리 `register`)
 - [x] Keycloak Admin Client 연동 (register, login, logout, withdraw, changePassword)
-- [x] KeycloakProperties (@ConfigurationProperties + @Validated)
-- [x] 회원가입 API (MASTER 권한 차단, 보상 트랜잭션)
-- [x] 로그인/로그아웃 API (Keycloak 토큰 발급/무효화)
-- [x] /me 엔드포인트 (@RequestHeader 방식)
-- [x] 사용자 CRUD (단건조회, 목록조회, 수정, 삭제) + MASTER 권한 체크
-- [x] 삭제 시 requesterId 전달 (감사 추적)
-- [x] 예외 분리 + 개인정보 미노출
-- [x] TokenData 도메인 레벨 분리 (계층 위반 해소)
-- [x] 코드래빗 리뷰 전체 반영
+- [x] `KeycloakProperties` (`@ConfigurationProperties` + `@Validated`)
+- [x] 회원가입 API + MASTER 권한 차단 + 보상 트랜잭션
+- [x] 로그인/로그아웃 API
+- [x] `/me` 엔드포인트 (X-User-UUID 헤더)
+- [x] 사용자 CRUD + MASTER 권한 체크 + 감사 추적
+- [x] 사용자 검색 필터 (`?role=&hubId=`)
+- [x] 사용자 Internal API (`/internal/users/**`)
+- [x] **Courier 도메인 완성** — Service, Controller, DTO, Exception
+- [x] **Courier 등록 turn 동시성 방어** — 유니크 제약 + 재시도 루프
+- [x] **Courier Internal API** (`/internal/couriers/**`) — 라운드로빈 후보 조회
+- [x] **HubProvider Feign 연동** — 회원가입/Courier 등록 시 hub-service에서 hubName 실시간 fetch
+- [x] HubProvider 원격 장애 분리 (`FeignException.NotFound` ↔ 그 외)
+- [x] HubProvider 응답 hubId 검증 (업스트림 오동작 방어)
+- [x] 코드래빗 리뷰 다회 반영
 
-### TODO
-- [ ] 검색 필터 (keyword, role, user_id — QueryDSL)
-- [ ] CourierService + CourierController
-- [ ] SecurityUtil 전환 (common publish 후 팀 전체 일괄)
-- [ ] softDelete → delete 전환 (Keycloak 탈퇴 동기화)
-- [ ] HubProvider 구현 (Feign Client → hub-service)
-- [ ] CompanyProvider 구현 (Feign Client → company-service)
-- [ ] Dockerfile + Docker 배포
-- [ ] GitHub Actions CI/CD
+### 🟡 다음
+- [ ] `softDelete` → `delete` 통일 (Keycloak 탈퇴와 트랜잭션 동기화)
+- [ ] `CompanyProvider` Feign 구현 — 현재 `companyName` 빈 문자열
+- [ ] 사용자 검색 keyword 필터 (이름/이메일 LIKE) — QueryDSL
+- [ ] Courier 허브 이동 흐름 (별도 도메인 메서드 + turn 재배정)
+- [ ] User 변경 이벤트 발행 (`user.updated`, `user.deleted`) — Outbox
+
+### 🔵 추후
+- [ ] `SecurityUtil` 전환 (common Phase 4, 전 서비스 일괄)
+- [ ] hub-service `hub.updated` 이벤트 구독 (hubName 동기화)
+- [ ] Redis 캐싱 (Internal API 응답)
+- [ ] Dockerfile + Docker 배포 + GitHub Actions CI/CD
+
+---
+
+## 🤝 다른 서비스와의 관계
+
+### user-service가 호출하는 곳
+- **hub-service** (`GET /api/hubs/{hubId}`) — `HubProvider`로 hubName fetch
+- **Keycloak** (`/realms/my-realm/...`) — 인증 흐름
+
+### user-service를 호출하는 곳
+- **delivery-service** (Feign)
+  - `GET /internal/users/{userId}` — 사용자 검증
+  - `GET /internal/couriers?hubId=&type=` — 배정 후보 리스트
+  - `GET /internal/couriers/{courierId}` — 알림 발송 시 정보 조회
+- **gateway** — `/api/users/**`, `/api/couriers/**` 외부 트래픽 라우팅
+
+### Courier 책임 분리
+- user-service: Courier 엔티티 owner (등록, 조회, 수정, 삭제, 후보 제공)
+- delivery-service: Courier **사용자** (Feign으로 후보 받아 라운드로빈 배정 + 배송 레코드에 `assignedCourierId` 저장)
+- 양쪽이 같은 엔티티를 갖지 않음 → 동기화 이벤트 불필요
+
+---
+
+## 📖 관련 PR / 이슈
+
+- PR #4 — Internal User/Courier API + 검색 필터 + HubProvider Feign + Courier 도메인 완성
+- gateway PR — `/api/couriers/**` 라우팅 추가 + `/internal/**` 라우팅 보안상 제외

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ loopang MSA 프로젝트의 **유저 + 배송담당자(Courier) 도메인** 서�
 | GET | `/internal/users/{userId}` | 단건 조회 (권한 검증 없음) |
 | GET | `/internal/users?role=&hubId=` | 리스트 조회 (페이지네이션 X, `enabled=true` 필터) |
 
-> ⚠️ **`/internal/**` 경로는 gateway 라우팅에서 제외되어 있습니다.** 서비스 간 Feign 호출은 Eureka 디스커버리로 user-service 인스턴스에 직접 도달하므로 gateway 우회. 외부 클라이언트는 접근 불가.
+> ⚠️ **`/internal/**` 경로는 gateway 라우팅에서 제외되어 있습니다.** 서비스 간 Feign 호출은 Eureka 디스커버리로 user-service 인스턴스에 직접 도달하므로 gateway 우회. 외부 클라이언트는 gateway를 통해 접근할 수 없으나, **user-service 포드/인스턴스가 네트워크에서 직접 노출되면 무인증 엔드포인트가 그대로 열린다**. ALB Listener Rule, Security Group, 또는 내부망 접근 제한 등 배포 시 네트워크 보안 설정이 적용된 환경을 전제로 한다.
 
 ### 🚚 배송담당자 (외부 — `/api/couriers/**`)
 
@@ -129,7 +129,7 @@ loopang MSA 프로젝트의 **유저 + 배송담당자(Courier) 도메인** 서�
 
 ### 회원가입 (POST /api/users)
 
-```
+```text
 1. Request 검증 (이메일/슬랙ID 중복, MASTER 권한 차단)
 2. HubProvider.get(hubId)
    ├─ FeignException.NotFound → NotFoundException(404)
@@ -143,21 +143,21 @@ loopang MSA 프로젝트의 **유저 + 배송담당자(Courier) 도메인** 서�
 
 ### 배송담당자 등록 (POST /api/couriers)
 
-```
+```text
 1. user 조회 + 검증 (role=DELIVERY, enabled=true, hubInfo 필수)
 2. 중복 등록 확인 (findByUser_Id)
 3. HubProvider.get(user.hubInfo.hubId)
    → 회원가입 시점 이후 허브명이 바뀌었을 수 있으므로 hub-service에서 최신값 fetch
 4. saveWithTurnRetry() — 동시성 방어
-   ├─ findMaxDeliveryTurn(hubId, type) + 1
-   ├─ Courier.register(user, hubInfo, type, nextTurn) → save
+   ├─ findMaxDeliveryTurnIncludingDeleted(hubId, type) + 1   (soft-deleted 포함 monotonic)
+   ├─ Courier.register(user, hubInfo, type, nextTurn) → saveAndFlush
    └─ DataIntegrityViolationException catch 시 max+1 다시 읽고 재시도 (최대 5회)
 5. 5회 모두 실패 시 InternalServerException
 ```
 
 ### 라운드로빈 후보 조회 (GET /internal/couriers)
 
-```
+```text
 delivery-service Feign 호출
   ↓
 1. findAllByHubInfo_HubIdAndTypeOrderByDeliveryTurnAsc(hubId, type)
@@ -178,11 +178,14 @@ delivery-service: 라운드로빈으로 1명 선정 → 배송 레코드에 assi
 | `GET /api/hubs/{hubId}` | 회원가입/수정/Courier 등록 시 최신 `hubName` 조회 |
 
 **오류 처리 (`HubProviderImpl`):**
-| FeignException | 변환 | HTTP |
+
+| 케이스 | 변환 | HTTP |
 |---|---|---|
-| `FeignException.NotFound` | `NotFoundException` | 404 |
-| 그 외 (`5xx`, 타임아웃, 연결 실패) | `InternalServerException` | 500 |
+| `FeignException.NotFound` (404) | `NotFoundException` | 404 |
+| 200 응답 + `data == null` | `NotFoundException` | 404 |
+| 그 외 `FeignException` (5xx, 타임아웃, 연결 실패) | `InternalServerException` | 500 |
 | 응답 직렬화 실패 등 | `InternalServerException` | 500 |
+| 200 응답 + 필수 필드 누락 (`hubId`/`name` null/blank) | `InternalServerException` | 500 |
 | 응답 hubId ≠ 요청 hubId | `InternalServerException` | 500 |
 
 ### Keycloak — `KeycloakIdentityProvider`
@@ -221,7 +224,7 @@ delivery-service: 라운드로빈으로 1명 선정 → 배송 레코드에 assi
 
 ## 🧱 클린 아키텍처
 
-```
+```text
 com.loopang.userservice
 ├── application/
 │   └── service/

--- a/build.gradle
+++ b/build.gradle
@@ -33,7 +33,7 @@ repositories {
 
 dependencies {
     // 공통 모듈
-    implementation 'com.loopang:common:0.0.4-SNAPSHOT'
+    implementation 'com.loopang:common:0.0.5-SNAPSHOT'
     //keycloak
     implementation 'org.springframework.boot:spring-boot-starter-oauth2-resource-server'
     implementation 'org.keycloak:keycloak-admin-client:24.0.0'

--- a/src/main/java/com/loopang/userservice/application/service/CourierService.java
+++ b/src/main/java/com/loopang/userservice/application/service/CourierService.java
@@ -38,18 +38,21 @@ public class CourierService {
     private final CourierRepository courierRepository;
     private final UserRepository userRepository;
     private final HubProvider hubProvider;
+    private final CourierTurnAllocator turnAllocator;
 
     /**
      * 배송담당자 등록.
      * <ol>
      *   <li>userId로 user 조회 + 검증 (role=DELIVERY, enabled=true, hubInfo!=null)</li>
      *   <li>이미 등록된 user인지 중복 체크</li>
-     *   <li>HubProvider로 hub-service에서 최신 hubInfo 조회 — 회원가입 시점 이후 허브명이 바뀌었을 수 있음</li>
-     *   <li>같은 허브 + 같은 타입의 max(deliveryTurn) + 1로 자동 할당</li>
-     *   <li>Courier 생성 + 저장</li>
+     *   <li>HubProvider로 hub-service에서 최신 hubInfo 조회 (외부 호출, readOnly tx 안)</li>
+     *   <li>{@link CourierTurnAllocator#registerInNewTx}을 호출 — 매 시도가 새 트랜잭션이라
+     *       {@code DataIntegrityViolationException}이 발생해도 부모 tx는 영향 없이 다음 시도로 진행</li>
      * </ol>
+     *
+     * <p>본 메서드는 클래스 레벨 {@code @Transactional(readOnly=true)}만 적용된다.
+     * 쓰기 작업은 전부 {@code CourierTurnAllocator}의 {@code REQUIRES_NEW} 메서드에서 일어난다.</p>
      */
-    @Transactional
     public CourierResponseDto register(CourierCreateRequestDto request) {
         User user = userRepository.findById(request.getUserId())
                 .orElseThrow(() -> new UserNotFoundException(request.getUserId()));
@@ -72,9 +75,22 @@ public class CourierService {
         // 등록 시점의 최신 허브 정보 조회 (회원가입 시점과 다를 수 있음)
         HubInfo hubInfo = hubProvider.get(user.getHubInfo().getHubId());
 
-        // (hub_id, type, delivery_turn) 유니크 제약 + 충돌 시 재시도로 race condition 방어
-        Courier saved = saveWithTurnRetry(user, hubInfo, request.getDeliveryChargeType());
-        return CourierResponseDto.from(saved);
+        // 새 트랜잭션 단위로 재시도 — JPA rollback-only 마킹 회피
+        for (int attempt = 1; attempt <= MAX_TURN_RETRY; attempt++) {
+            try {
+                Courier saved = turnAllocator.registerInNewTx(
+                        user.getId(), hubInfo, request.getDeliveryChargeType());
+                return CourierResponseDto.from(saved);
+            } catch (DataIntegrityViolationException e) {
+                log.warn("[CourierService] turn 충돌 재시도 (attempt {}/{}, userId={}, hubId={}, type={})",
+                        attempt, MAX_TURN_RETRY, user.getId(), hubInfo.getHubId(), request.getDeliveryChargeType());
+                if (attempt == MAX_TURN_RETRY) {
+                    throw new InternalServerException(
+                            "배송담당자 등록 중 동시성 충돌이 반복되었습니다.");
+                }
+            }
+        }
+        throw new InternalServerException("배송담당자 등록에 실패했습니다.");
     }
 
     public CourierResponseDto getCourier(UUID courierId) {
@@ -97,39 +113,31 @@ public class CourierService {
 
     /**
      * 타입 변경 시 새 deliveryTurn을 자동 재할당.
-     * (HUB → COMPANY로 바뀌면 새 타입의 max+1 자리로 들어감)
-     * 동시 변경 race를 막기 위해 unique 충돌 시 재시도.
+     * 매 시도가 새 트랜잭션이라 unique 충돌 발생 시 부모 tx 영향 없이 재시도.
      */
-    @Transactional
     public CourierResponseDto updateCourier(UUID courierId, CourierUpdateRequestDto request) {
-        Courier courier = findCourierById(courierId);
+        Courier courier = findCourierById(courierId); // 존재 여부 1차 확인
 
-        if (request.getDeliveryChargeType() != null
-                && request.getDeliveryChargeType() != courier.getType()) {
-            DeliveryChargeType newType = request.getDeliveryChargeType();
-            UUID hubId = courier.getHubInfo().getHubId();
+        if (request.getDeliveryChargeType() == null
+                || request.getDeliveryChargeType() == courier.getType()) {
+            return CourierResponseDto.from(courier);
+        }
 
-            for (int attempt = 1; attempt <= MAX_TURN_RETRY; attempt++) {
-                // monotonic 할당 — soft-deleted 행도 포함한 max + 1
-                int nextTurn = courierRepository
-                        .findMaxDeliveryTurnIncludingDeleted(hubId, newType.name()) + 1;
-                try {
-                    courier.changeType(newType, nextTurn);
-                    // saveAndFlush — commit 시점이 아닌 지금 즉시 flush해 unique 충돌을 try/catch에서 잡음
-                    courierRepository.saveAndFlush(courier);
-                    break;
-                } catch (DataIntegrityViolationException e) {
-                    log.warn("[CourierService] turn 충돌 재시도 (attempt {}/{}, hubId={}, type={})",
-                            attempt, MAX_TURN_RETRY, hubId, newType);
-                    if (attempt == MAX_TURN_RETRY) {
-                        throw new InternalServerException(
-                                "배송담당자 타입 변경 중 동시성 충돌이 반복되었습니다.");
-                    }
+        DeliveryChargeType newType = request.getDeliveryChargeType();
+        for (int attempt = 1; attempt <= MAX_TURN_RETRY; attempt++) {
+            try {
+                Courier updated = turnAllocator.changeTypeInNewTx(courierId, newType);
+                return CourierResponseDto.from(updated);
+            } catch (DataIntegrityViolationException e) {
+                log.warn("[CourierService] turn 충돌 재시도 (attempt {}/{}, courierId={}, newType={})",
+                        attempt, MAX_TURN_RETRY, courierId, newType);
+                if (attempt == MAX_TURN_RETRY) {
+                    throw new InternalServerException(
+                            "배송담당자 타입 변경 중 동시성 충돌이 반복되었습니다.");
                 }
             }
         }
-
-        return CourierResponseDto.from(courier);
+        throw new InternalServerException("배송담당자 타입 변경에 실패했습니다.");
     }
 
     @Transactional
@@ -160,38 +168,5 @@ public class CourierService {
     private Courier findCourierById(UUID courierId) {
         return courierRepository.findById(courierId)
                 .orElseThrow(() -> new CourierNotFoundException(courierId));
-    }
-
-    /**
-     * 신규 등록 시 (hub_id, type, delivery_turn) unique 제약 충돌이 나면 max+1을 다시 읽어 재시도.
-     * 최대 {@value #MAX_TURN_RETRY}회.
-     *
-     * <p>turn 계산은 {@link CourierRepository#findMaxDeliveryTurnIncludingDeleted}를 사용해
-     * soft-deleted 행까지 포함한 monotonic 할당. 이래야 등록/삭제가 반복돼도 turn이 tombstone과
-     * 충돌해 무한 retry로 빠지지 않는다.</p>
-     *
-     * <p>{@code saveAndFlush}로 commit이 아닌 즉시 flush를 강제해 unique 충돌을 try/catch에서 잡는다.
-     * {@code save}만 호출하면 충돌이 commit 시점에 발생해 try/catch를 우회해버린다.</p>
-     */
-    private Courier saveWithTurnRetry(User user,
-                                      HubInfo hubInfo,
-                                      DeliveryChargeType type) {
-        for (int attempt = 1; attempt <= MAX_TURN_RETRY; attempt++) {
-            int nextTurn = courierRepository
-                    .findMaxDeliveryTurnIncludingDeleted(hubInfo.getHubId(), type.name()) + 1;
-            try {
-                Courier courier = Courier.register(user, hubInfo, type, nextTurn);
-                return courierRepository.saveAndFlush(courier);
-            } catch (DataIntegrityViolationException e) {
-                log.warn("[CourierService] turn 충돌 재시도 (attempt {}/{}, hubId={}, type={}, candidateTurn={})",
-                        attempt, MAX_TURN_RETRY, hubInfo.getHubId(), type, nextTurn);
-                if (attempt == MAX_TURN_RETRY) {
-                    throw new InternalServerException(
-                            "배송담당자 등록 중 동시성 충돌이 반복되었습니다.");
-                }
-            }
-        }
-        // unreachable
-        throw new InternalServerException("배송담당자 등록에 실패했습니다.");
     }
 }

--- a/src/main/java/com/loopang/userservice/application/service/CourierService.java
+++ b/src/main/java/com/loopang/userservice/application/service/CourierService.java
@@ -1,0 +1,145 @@
+package com.loopang.userservice.application.service;
+
+import com.loopang.common.exception.BadRequestException;
+import com.loopang.userservice.domain.entity.Courier;
+import com.loopang.userservice.domain.entity.User;
+import com.loopang.userservice.domain.exception.CourierDuplicateException;
+import com.loopang.userservice.domain.exception.CourierNotFoundException;
+import com.loopang.userservice.domain.exception.UserNotFoundException;
+import com.loopang.userservice.domain.repository.CourierRepository;
+import com.loopang.userservice.domain.repository.UserRepository;
+import com.loopang.userservice.domain.service.HubProvider;
+import com.loopang.userservice.domain.vo.DeliveryChargeType;
+import com.loopang.userservice.domain.vo.HubInfo;
+import com.loopang.userservice.domain.vo.UserType;
+import com.loopang.userservice.presentation.dto.CourierCreateRequestDto;
+import com.loopang.userservice.presentation.dto.CourierUpdateRequestDto;
+import com.loopang.userservice.presentation.dto.response.CourierResponseDto;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.UUID;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class CourierService {
+
+    private final CourierRepository courierRepository;
+    private final UserRepository userRepository;
+    private final HubProvider hubProvider;
+
+    /**
+     * 배송담당자 등록.
+     * <ol>
+     *   <li>userId로 user 조회 + 검증 (role=DELIVERY, enabled=true, hubInfo!=null)</li>
+     *   <li>이미 등록된 user인지 중복 체크</li>
+     *   <li>HubProvider로 hub-service에서 최신 hubInfo 조회 — 회원가입 시점 이후 허브명이 바뀌었을 수 있음</li>
+     *   <li>같은 허브 + 같은 타입의 max(deliveryTurn) + 1로 자동 할당</li>
+     *   <li>Courier 생성 + 저장</li>
+     * </ol>
+     */
+    @Transactional
+    public CourierResponseDto register(CourierCreateRequestDto request) {
+        User user = userRepository.findById(request.getUserId())
+                .orElseThrow(() -> new UserNotFoundException(request.getUserId()));
+
+        if (user.getRole() != UserType.DELIVERY) {
+            throw new BadRequestException("배송담당자 권한(DELIVERY)을 가진 사용자만 등록할 수 있습니다.");
+        }
+        if (!user.isEnabled()) {
+            throw new BadRequestException("승인되지 않았거나 탈퇴한 사용자입니다.");
+        }
+        if (user.getHubInfo() == null || user.getHubInfo().getHubId() == null) {
+            throw new BadRequestException("사용자에게 소속 허브가 없습니다.");
+        }
+
+        courierRepository.findByUser_Id(user.getId())
+                .ifPresent(existing -> {
+                    throw new CourierDuplicateException(user.getId());
+                });
+
+        // 등록 시점의 최신 허브 정보 조회 (회원가입 시점과 다를 수 있음)
+        HubInfo hubInfo = hubProvider.get(user.getHubInfo().getHubId());
+
+        int nextTurn = courierRepository
+                .findMaxDeliveryTurn(hubInfo.getHubId(), request.getDeliveryChargeType())
+                .orElse(0) + 1;
+
+        Courier courier = Courier.register(user, hubInfo, request.getDeliveryChargeType(), nextTurn);
+        return CourierResponseDto.from(courierRepository.save(courier));
+    }
+
+    public CourierResponseDto getCourier(UUID courierId) {
+        return CourierResponseDto.from(findCourierById(courierId));
+    }
+
+    public Page<CourierResponseDto> getCouriers(UUID hubId, DeliveryChargeType type, Pageable pageable) {
+        Page<Courier> page;
+        if (hubId != null && type != null) {
+            page = courierRepository.findAllByHubInfo_HubIdAndType(hubId, type, pageable);
+        } else if (hubId != null) {
+            page = courierRepository.findAllByHubInfo_HubId(hubId, pageable);
+        } else if (type != null) {
+            page = courierRepository.findAllByType(type, pageable);
+        } else {
+            page = courierRepository.findAll(pageable);
+        }
+        return page.map(CourierResponseDto::from);
+    }
+
+    /**
+     * 타입 변경 시 새 deliveryTurn을 자동 재할당.
+     * (HUB → COMPANY로 바뀌면 새 타입의 max+1 자리로 들어감)
+     */
+    @Transactional
+    public CourierResponseDto updateCourier(UUID courierId, CourierUpdateRequestDto request) {
+        Courier courier = findCourierById(courierId);
+
+        if (request.getDeliveryChargeType() != null
+                && request.getDeliveryChargeType() != courier.getType()) {
+            int nextTurn = courierRepository
+                    .findMaxDeliveryTurn(courier.getHubInfo().getHubId(), request.getDeliveryChargeType())
+                    .orElse(0) + 1;
+            courier.changeType(request.getDeliveryChargeType(), nextTurn);
+        }
+
+        return CourierResponseDto.from(courier);
+    }
+
+    @Transactional
+    public void deleteCourier(UUID courierId, UUID deletedBy) {
+        Courier courier = findCourierById(courierId);
+        // TODO: SecurityUtil 전환 후 deletedBy 전달
+        courier.softDelete(deletedBy);
+    }
+
+    /**
+     * 내부 호출용 — delivery-service가 라운드로빈 배정을 위해 후보를 조회.
+     * deliveryTurn ASC 정렬, soft-deleted 자동 제외.
+     * 소속 user가 enabled=false인 courier는 후보에서 제외.
+     */
+    public List<CourierResponseDto> findCandidatesForAssignment(UUID hubId, DeliveryChargeType type) {
+        return courierRepository
+                .findAllByHubInfo_HubIdAndTypeOrderByDeliveryTurnAsc(hubId, type)
+                .stream()
+                .filter(c -> c.getUser() != null && c.getUser().isEnabled())
+                .map(CourierResponseDto::from)
+                .toList();
+    }
+
+    public CourierResponseDto getInternalCourier(UUID courierId) {
+        return CourierResponseDto.from(findCourierById(courierId));
+    }
+
+    private Courier findCourierById(UUID courierId) {
+        return courierRepository.findById(courierId)
+                .orElseThrow(() -> new CourierNotFoundException(courierId));
+    }
+}

--- a/src/main/java/com/loopang/userservice/application/service/CourierService.java
+++ b/src/main/java/com/loopang/userservice/application/service/CourierService.java
@@ -1,6 +1,7 @@
 package com.loopang.userservice.application.service;
 
 import com.loopang.common.exception.BadRequestException;
+import com.loopang.common.exception.InternalServerException;
 import com.loopang.userservice.domain.entity.Courier;
 import com.loopang.userservice.domain.entity.User;
 import com.loopang.userservice.domain.exception.CourierDuplicateException;
@@ -17,6 +18,7 @@ import com.loopang.userservice.presentation.dto.CourierUpdateRequestDto;
 import com.loopang.userservice.presentation.dto.response.CourierResponseDto;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
@@ -30,6 +32,8 @@ import java.util.UUID;
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
 public class CourierService {
+
+    private static final int MAX_TURN_RETRY = 5;
 
     private final CourierRepository courierRepository;
     private final UserRepository userRepository;
@@ -68,12 +72,10 @@ public class CourierService {
         // 등록 시점의 최신 허브 정보 조회 (회원가입 시점과 다를 수 있음)
         HubInfo hubInfo = hubProvider.get(user.getHubInfo().getHubId());
 
-        int nextTurn = courierRepository
-                .findMaxDeliveryTurn(hubInfo.getHubId(), request.getDeliveryChargeType())
-                .orElse(0) + 1;
-
-        Courier courier = Courier.register(user, hubInfo, request.getDeliveryChargeType(), nextTurn);
-        return CourierResponseDto.from(courierRepository.save(courier));
+        // (hub_id, type, delivery_turn) 유니크 제약 + 충돌 시 재시도로 race condition 방어
+        Courier saved = saveWithTurnRetry(
+                user, hubInfo, request.getDeliveryChargeType(), null);
+        return CourierResponseDto.from(saved);
     }
 
     public CourierResponseDto getCourier(UUID courierId) {
@@ -97,6 +99,7 @@ public class CourierService {
     /**
      * 타입 변경 시 새 deliveryTurn을 자동 재할당.
      * (HUB → COMPANY로 바뀌면 새 타입의 max+1 자리로 들어감)
+     * 동시 변경 race를 막기 위해 unique 충돌 시 재시도.
      */
     @Transactional
     public CourierResponseDto updateCourier(UUID courierId, CourierUpdateRequestDto request) {
@@ -104,10 +107,24 @@ public class CourierService {
 
         if (request.getDeliveryChargeType() != null
                 && request.getDeliveryChargeType() != courier.getType()) {
-            int nextTurn = courierRepository
-                    .findMaxDeliveryTurn(courier.getHubInfo().getHubId(), request.getDeliveryChargeType())
-                    .orElse(0) + 1;
-            courier.changeType(request.getDeliveryChargeType(), nextTurn);
+            DeliveryChargeType newType = request.getDeliveryChargeType();
+            UUID hubId = courier.getHubInfo().getHubId();
+
+            for (int attempt = 1; attempt <= MAX_TURN_RETRY; attempt++) {
+                int nextTurn = courierRepository.findMaxDeliveryTurn(hubId, newType).orElse(0) + 1;
+                try {
+                    courier.changeType(newType, nextTurn);
+                    courierRepository.save(courier); // flush 유도해 unique 충돌을 즉시 catch
+                    break;
+                } catch (DataIntegrityViolationException e) {
+                    log.warn("[CourierService] turn 충돌 재시도 (attempt {}/{}, hubId={}, type={})",
+                            attempt, MAX_TURN_RETRY, hubId, newType);
+                    if (attempt == MAX_TURN_RETRY) {
+                        throw new InternalServerException(
+                                "배송담당자 타입 변경 중 동시성 충돌이 반복되었습니다.");
+                    }
+                }
+            }
         }
 
         return CourierResponseDto.from(courier);
@@ -141,5 +158,31 @@ public class CourierService {
     private Courier findCourierById(UUID courierId) {
         return courierRepository.findById(courierId)
                 .orElseThrow(() -> new CourierNotFoundException(courierId));
+    }
+
+    /**
+     * 신규 등록 시 (hub_id, type, delivery_turn) unique 제약 충돌이 나면 max+1을 다시 읽어 재시도.
+     * 최대 {@value #MAX_TURN_RETRY}회.
+     */
+    private Courier saveWithTurnRetry(User user,
+                                      HubInfo hubInfo,
+                                      DeliveryChargeType type,
+                                      Integer ignoredCurrentTurn) {
+        for (int attempt = 1; attempt <= MAX_TURN_RETRY; attempt++) {
+            int nextTurn = courierRepository.findMaxDeliveryTurn(hubInfo.getHubId(), type).orElse(0) + 1;
+            try {
+                Courier courier = Courier.register(user, hubInfo, type, nextTurn);
+                return courierRepository.save(courier);
+            } catch (DataIntegrityViolationException e) {
+                log.warn("[CourierService] turn 충돌 재시도 (attempt {}/{}, hubId={}, type={}, candidateTurn={})",
+                        attempt, MAX_TURN_RETRY, hubInfo.getHubId(), type, nextTurn);
+                if (attempt == MAX_TURN_RETRY) {
+                    throw new InternalServerException(
+                            "배송담당자 등록 중 동시성 충돌이 반복되었습니다.");
+                }
+            }
+        }
+        // unreachable
+        throw new InternalServerException("배송담당자 등록에 실패했습니다.");
     }
 }

--- a/src/main/java/com/loopang/userservice/application/service/CourierService.java
+++ b/src/main/java/com/loopang/userservice/application/service/CourierService.java
@@ -73,8 +73,7 @@ public class CourierService {
         HubInfo hubInfo = hubProvider.get(user.getHubInfo().getHubId());
 
         // (hub_id, type, delivery_turn) 유니크 제약 + 충돌 시 재시도로 race condition 방어
-        Courier saved = saveWithTurnRetry(
-                user, hubInfo, request.getDeliveryChargeType(), null);
+        Courier saved = saveWithTurnRetry(user, hubInfo, request.getDeliveryChargeType());
         return CourierResponseDto.from(saved);
     }
 
@@ -111,10 +110,13 @@ public class CourierService {
             UUID hubId = courier.getHubInfo().getHubId();
 
             for (int attempt = 1; attempt <= MAX_TURN_RETRY; attempt++) {
-                int nextTurn = courierRepository.findMaxDeliveryTurn(hubId, newType).orElse(0) + 1;
+                // monotonic 할당 — soft-deleted 행도 포함한 max + 1
+                int nextTurn = courierRepository
+                        .findMaxDeliveryTurnIncludingDeleted(hubId, newType.name()) + 1;
                 try {
                     courier.changeType(newType, nextTurn);
-                    courierRepository.save(courier); // flush 유도해 unique 충돌을 즉시 catch
+                    // saveAndFlush — commit 시점이 아닌 지금 즉시 flush해 unique 충돌을 try/catch에서 잡음
+                    courierRepository.saveAndFlush(courier);
                     break;
                 } catch (DataIntegrityViolationException e) {
                     log.warn("[CourierService] turn 충돌 재시도 (attempt {}/{}, hubId={}, type={})",
@@ -163,16 +165,23 @@ public class CourierService {
     /**
      * 신규 등록 시 (hub_id, type, delivery_turn) unique 제약 충돌이 나면 max+1을 다시 읽어 재시도.
      * 최대 {@value #MAX_TURN_RETRY}회.
+     *
+     * <p>turn 계산은 {@link CourierRepository#findMaxDeliveryTurnIncludingDeleted}를 사용해
+     * soft-deleted 행까지 포함한 monotonic 할당. 이래야 등록/삭제가 반복돼도 turn이 tombstone과
+     * 충돌해 무한 retry로 빠지지 않는다.</p>
+     *
+     * <p>{@code saveAndFlush}로 commit이 아닌 즉시 flush를 강제해 unique 충돌을 try/catch에서 잡는다.
+     * {@code save}만 호출하면 충돌이 commit 시점에 발생해 try/catch를 우회해버린다.</p>
      */
     private Courier saveWithTurnRetry(User user,
                                       HubInfo hubInfo,
-                                      DeliveryChargeType type,
-                                      Integer ignoredCurrentTurn) {
+                                      DeliveryChargeType type) {
         for (int attempt = 1; attempt <= MAX_TURN_RETRY; attempt++) {
-            int nextTurn = courierRepository.findMaxDeliveryTurn(hubInfo.getHubId(), type).orElse(0) + 1;
+            int nextTurn = courierRepository
+                    .findMaxDeliveryTurnIncludingDeleted(hubInfo.getHubId(), type.name()) + 1;
             try {
                 Courier courier = Courier.register(user, hubInfo, type, nextTurn);
-                return courierRepository.save(courier);
+                return courierRepository.saveAndFlush(courier);
             } catch (DataIntegrityViolationException e) {
                 log.warn("[CourierService] turn 충돌 재시도 (attempt {}/{}, hubId={}, type={}, candidateTurn={})",
                         attempt, MAX_TURN_RETRY, hubInfo.getHubId(), type, nextTurn);

--- a/src/main/java/com/loopang/userservice/application/service/CourierService.java
+++ b/src/main/java/com/loopang/userservice/application/service/CourierService.java
@@ -18,10 +18,12 @@ import com.loopang.userservice.presentation.dto.CourierUpdateRequestDto;
 import com.loopang.userservice.presentation.dto.response.CourierResponseDto;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.hibernate.exception.ConstraintViolationException;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
@@ -43,17 +45,21 @@ public class CourierService {
     /**
      * 배송담당자 등록.
      * <ol>
-     *   <li>userId로 user 조회 + 검증 (role=DELIVERY, enabled=true, hubInfo!=null)</li>
-     *   <li>이미 등록된 user인지 중복 체크</li>
-     *   <li>HubProvider로 hub-service에서 최신 hubInfo 조회 (외부 호출, readOnly tx 안)</li>
-     *   <li>{@link CourierTurnAllocator#registerInNewTx}을 호출 — 매 시도가 새 트랜잭션이라
-     *       {@code DataIntegrityViolationException}이 발생해도 부모 tx는 영향 없이 다음 시도로 진행</li>
+     *   <li>user 조회 + 검증 (Spring Data JPA repository 호출 단위로 짧은 implicit tx)</li>
+     *   <li>{@link HubProvider#get} 외부 Feign 호출 — 어떤 트랜잭션도 잡고 있지 않은 상태에서 실행</li>
+     *   <li>{@link CourierTurnAllocator#registerInNewTx} 반복 호출 (매 시도 새 tx)</li>
      * </ol>
      *
-     * <p>본 메서드는 클래스 레벨 {@code @Transactional(readOnly=true)}만 적용된다.
-     * 쓰기 작업은 전부 {@code CourierTurnAllocator}의 {@code REQUIRES_NEW} 메서드에서 일어난다.</p>
+     * <p><b>{@code @Transactional(propagation = NOT_SUPPORTED)}</b>로 클래스 레벨 readOnly tx를
+     * 일시 중단한다. 이렇게 하면 hub-service Feign 호출이 DB 커넥션을 점유하지 않아 hub-service가 느려져도
+     * user-service의 커넥션 풀이 고갈되지 않는다.</p>
+     *
+     * <p>repository 조회(findById, findByUser_Id)는 Spring Data JPA가 메서드 단위로 짧은 implicit
+     * 트랜잭션을 자동으로 만들어주므로 일관성 문제 없음.</p>
      */
+    @Transactional(propagation = Propagation.NOT_SUPPORTED)
     public CourierResponseDto register(CourierCreateRequestDto request) {
+        // 1. user 검증 (각 repo 호출이 자기 implicit tx를 가짐)
         User user = userRepository.findById(request.getUserId())
                 .orElseThrow(() -> new UserNotFoundException(request.getUserId()));
 
@@ -72,16 +78,20 @@ public class CourierService {
                     throw new CourierDuplicateException(user.getId());
                 });
 
-        // 등록 시점의 최신 허브 정보 조회 (회원가입 시점과 다를 수 있음)
+        // 2. Feign 호출 — 어떤 DB 트랜잭션도 보유하지 않은 상태
         HubInfo hubInfo = hubProvider.get(user.getHubInfo().getHubId());
 
-        // 새 트랜잭션 단위로 재시도 — JPA rollback-only 마킹 회피
+        // 3. 새 트랜잭션 단위로 재시도 — JPA rollback-only 마킹 회피
         for (int attempt = 1; attempt <= MAX_TURN_RETRY; attempt++) {
             try {
                 Courier saved = turnAllocator.registerInNewTx(
                         user.getId(), hubInfo, request.getDeliveryChargeType());
                 return CourierResponseDto.from(saved);
             } catch (DataIntegrityViolationException e) {
+                if (!isTurnConflict(e)) {
+                    // turn 충돌이 아닌 다른 무결성 오류는 즉시 전파 — 원인 진단 위해
+                    throw e;
+                }
                 log.warn("[CourierService] turn 충돌 재시도 (attempt {}/{}, userId={}, hubId={}, type={})",
                         attempt, MAX_TURN_RETRY, user.getId(), hubInfo.getHubId(), request.getDeliveryChargeType());
                 if (attempt == MAX_TURN_RETRY) {
@@ -129,6 +139,9 @@ public class CourierService {
                 Courier updated = turnAllocator.changeTypeInNewTx(courierId, newType);
                 return CourierResponseDto.from(updated);
             } catch (DataIntegrityViolationException e) {
+                if (!isTurnConflict(e)) {
+                    throw e;
+                }
                 log.warn("[CourierService] turn 충돌 재시도 (attempt {}/{}, courierId={}, newType={})",
                         attempt, MAX_TURN_RETRY, courierId, newType);
                 if (attempt == MAX_TURN_RETRY) {
@@ -168,5 +181,31 @@ public class CourierService {
     private Courier findCourierById(UUID courierId) {
         return courierRepository.findById(courierId)
                 .orElseThrow(() -> new CourierNotFoundException(courierId));
+    }
+
+    /**
+     * {@code DataIntegrityViolationException}의 cause 체인을 훑어 turn 유니크 제약
+     * (`uk_courier_hub_type_turn`) 충돌인지 식별한다.
+     *
+     * <p>이 검사가 없으면 다른 무결성 오류(예: NOT NULL 위반, FK 위반)도 turn 충돌로 오인되어
+     * "동시성 충돌"이라는 잘못된 메시지로 5회 재시도되고 원인 진단이 어려워진다.</p>
+     */
+    private boolean isTurnConflict(DataIntegrityViolationException e) {
+        Throwable cause = e.getCause();
+        while (cause != null) {
+            if (cause instanceof ConstraintViolationException cve) {
+                String name = cve.getConstraintName();
+                if (name != null && name.toLowerCase().contains("uk_courier_hub_type_turn")) {
+                    return true;
+                }
+            }
+            // 일부 드라이버는 메시지에 제약명이 포함될 수 있어 fallback으로도 검사
+            String msg = cause.getMessage();
+            if (msg != null && msg.toLowerCase().contains("uk_courier_hub_type_turn")) {
+                return true;
+            }
+            cause = cause.getCause();
+        }
+        return false;
     }
 }

--- a/src/main/java/com/loopang/userservice/application/service/CourierTurnAllocator.java
+++ b/src/main/java/com/loopang/userservice/application/service/CourierTurnAllocator.java
@@ -1,0 +1,71 @@
+package com.loopang.userservice.application.service;
+
+import com.loopang.userservice.domain.entity.Courier;
+import com.loopang.userservice.domain.entity.User;
+import com.loopang.userservice.domain.exception.CourierNotFoundException;
+import com.loopang.userservice.domain.exception.UserNotFoundException;
+import com.loopang.userservice.domain.repository.CourierRepository;
+import com.loopang.userservice.domain.repository.UserRepository;
+import com.loopang.userservice.domain.vo.DeliveryChargeType;
+import com.loopang.userservice.domain.vo.HubInfo;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.UUID;
+
+/**
+ * 배송담당자 등록/타입변경 시 {@code deliveryTurn}을 할당하는 단위 작업을
+ * <strong>독립 트랜잭션({@link Propagation#REQUIRES_NEW})</strong>으로 수행한다.
+ *
+ * <p><b>왜 별도 컴포넌트로 분리했나:</b><br>
+ * JPA 스펙상 {@code saveAndFlush}가 던진 {@code DataIntegrityViolationException}은
+ * 현재 트랜잭션을 rollback-only로 마킹하기 때문에, 같은 트랜잭션 안에서 catch 후 재시도해도
+ * 최종 commit이 {@code UnexpectedRollbackException}으로 실패한다. 따라서 매 시도를 새 트랜잭션에서
+ * 수행해야 하며, Spring AOP 프록시 특성상 같은 클래스 내부 메서드 호출은 트랜잭션이 적용되지 않으므로
+ * 별도 컴포넌트로 분리한다.</p>
+ *
+ * <p>호출자({@link CourierService})는 충돌 시 catch 후 다시 본 컴포넌트의 메서드를 호출해
+ * 새로운 트랜잭션으로 재시도한다.</p>
+ */
+@Component
+@RequiredArgsConstructor
+public class CourierTurnAllocator {
+
+    private final CourierRepository courierRepository;
+    private final UserRepository userRepository;
+
+    /**
+     * 신규 등록 — 새 트랜잭션에서 user 조회 → max+1 turn 계산 → saveAndFlush.
+     * <p>{@code DataIntegrityViolationException}이 발생하면 현재 트랜잭션만 롤백되고
+     * 호출자(부모 트랜잭션)는 영향받지 않는다.</p>
+     */
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public Courier registerInNewTx(UUID userId, HubInfo hubInfo, DeliveryChargeType type) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new UserNotFoundException(userId));
+
+        int nextTurn = courierRepository
+                .findMaxDeliveryTurnIncludingDeleted(hubInfo.getHubId(), type.name()) + 1;
+
+        Courier courier = Courier.register(user, hubInfo, type, nextTurn);
+        return courierRepository.saveAndFlush(courier);
+    }
+
+    /**
+     * 타입 변경 — 새 트랜잭션에서 courier 조회 → 새 max+1 turn 계산 → changeType → saveAndFlush.
+     */
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public Courier changeTypeInNewTx(UUID courierId, DeliveryChargeType newType) {
+        Courier courier = courierRepository.findById(courierId)
+                .orElseThrow(() -> new CourierNotFoundException(courierId));
+
+        UUID hubId = courier.getHubInfo().getHubId();
+        int nextTurn = courierRepository
+                .findMaxDeliveryTurnIncludingDeleted(hubId, newType.name()) + 1;
+
+        courier.changeType(newType, nextTurn);
+        return courierRepository.saveAndFlush(courier);
+    }
+}

--- a/src/main/java/com/loopang/userservice/application/service/UserService.java
+++ b/src/main/java/com/loopang/userservice/application/service/UserService.java
@@ -105,6 +105,8 @@ public class UserService {
             page = userRepository.findAllByRoleAndHubInfo_HubId(role, hubId, pageable);
         } else if (role != null) {
             page = userRepository.findAllByRole(role, pageable);
+        } else if (hubId != null) {
+            page = userRepository.findAllByHubInfo_HubId(hubId, pageable);
         } else {
             page = userRepository.findAll(pageable);
         }
@@ -122,13 +124,26 @@ public class UserService {
 
     /**
      * 내부 서비스 호출용 리스트 조회 (페이지네이션 없음).
-     * <p>특정 role의 사용자를 전체 조회하거나, hubId까지 함께 필터링한다.
+     * <p>role/hubId 조합 4가지를 모두 처리:
+     * <ul>
+     *   <li>role + hubId 둘 다 → 두 조건 AND</li>
+     *   <li>role만 → role 필터</li>
+     *   <li>hubId만 → 허브 필터</li>
+     *   <li>둘 다 null → 전체 (보호용 fallback)</li>
+     * </ul>
      * 결과는 {@code enabled=true}인 사용자만 반환 (배정 후보 부적합 케이스 제외).</p>
      */
     public List<UserResponseDto> searchInternal(UserType role, UUID hubId) {
-        List<User> users = (hubId != null)
-                ? userRepository.findAllByRoleAndHubInfo_HubId(role, hubId)
-                : userRepository.findAllByRole(role);
+        List<User> users;
+        if (role != null && hubId != null) {
+            users = userRepository.findAllByRoleAndHubInfo_HubId(role, hubId);
+        } else if (role != null) {
+            users = userRepository.findAllByRole(role);
+        } else if (hubId != null) {
+            users = userRepository.findAllByHubInfo_HubId(hubId);
+        } else {
+            users = userRepository.findAll(Pageable.unpaged()).getContent();
+        }
 
         return users.stream()
                 .filter(User::isEnabled)

--- a/src/main/java/com/loopang/userservice/application/service/UserService.java
+++ b/src/main/java/com/loopang/userservice/application/service/UserService.java
@@ -23,6 +23,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
 import java.util.UUID;
 
 @Slf4j
@@ -93,6 +94,31 @@ public class UserService {
 
     public Page<UserResponseDto> getUsers(Pageable pageable) {
         return userRepository.findAll(pageable).map(UserResponseDto::from);
+    }
+
+    /**
+     * 내부 서비스 호출용 단건 조회.
+     * <p>외부 노출 GET /api/users/{id}와 달리 권한 검증 없이 즉시 조회한다.
+     * 호출자(예: delivery-service)가 Courier 등록 시 user 검증 + hubId 복사에 사용한다.</p>
+     */
+    public UserResponseDto getInternalUser(UUID userId) {
+        return UserResponseDto.from(findUserById(userId));
+    }
+
+    /**
+     * 내부 서비스 호출용 리스트 조회 (페이지네이션 없음).
+     * <p>특정 role의 사용자를 전체 조회하거나, hubId까지 함께 필터링한다.
+     * 결과는 {@code enabled=true}인 사용자만 반환 (배정 후보 부적합 케이스 제외).</p>
+     */
+    public List<UserResponseDto> searchInternal(UserType role, UUID hubId) {
+        List<User> users = (hubId != null)
+                ? userRepository.findAllByRoleAndHubInfo_HubId(role, hubId)
+                : userRepository.findAllByRole(role);
+
+        return users.stream()
+                .filter(User::isEnabled)
+                .map(UserResponseDto::from)
+                .toList();
     }
 
     @Transactional

--- a/src/main/java/com/loopang/userservice/application/service/UserService.java
+++ b/src/main/java/com/loopang/userservice/application/service/UserService.java
@@ -7,6 +7,7 @@ import com.loopang.userservice.domain.exception.UserNotFoundException;
 import com.loopang.userservice.domain.exception.UserSlackIdDuplicateException;
 import com.loopang.userservice.domain.vo.UserType;
 import com.loopang.userservice.domain.repository.UserRepository;
+import com.loopang.userservice.domain.service.HubProvider;
 import com.loopang.userservice.domain.service.IdentityProvider;
 import com.loopang.userservice.domain.vo.CompanyInfo;
 import com.loopang.userservice.domain.vo.HubInfo;
@@ -34,6 +35,7 @@ public class UserService {
 
     private final UserRepository userRepository;
     private final IdentityProvider identityProvider;
+    private final HubProvider hubProvider;
 
     @Transactional
     public SignupResponseDto signup(SignupRequestDto request) {
@@ -48,6 +50,11 @@ public class UserService {
             throw new UserSlackIdDuplicateException(request.getSlackId());
         }
 
+        // hub-service Feign으로 실제 hubName을 채운다 (이전엔 빈 문자열로 저장됐음)
+        HubInfo hubInfo = request.getHubId() != null
+                ? hubProvider.get(request.getHubId())
+                : null;
+
         UUID keycloakUserId = identityProvider.register(request.getEmail(), request.getPassword());
 
         try {
@@ -57,7 +64,7 @@ public class UserService {
                     .name(request.getName())
                     .slackId(request.getSlackId())
                     .role(request.getRole())
-                    .hubInfo(new HubInfo(request.getHubId(), ""))
+                    .hubInfo(hubInfo)
                     .companyInfo(request.getCompanyId() != null
                             ? new CompanyInfo(request.getCompanyId(), "")
                             : null)
@@ -92,8 +99,16 @@ public class UserService {
         return UserResponseDto.from(findUserById(userId));
     }
 
-    public Page<UserResponseDto> getUsers(Pageable pageable) {
-        return userRepository.findAll(pageable).map(UserResponseDto::from);
+    public Page<UserResponseDto> getUsers(UserType role, UUID hubId, Pageable pageable) {
+        Page<User> page;
+        if (role != null && hubId != null) {
+            page = userRepository.findAllByRoleAndHubInfo_HubId(role, hubId, pageable);
+        } else if (role != null) {
+            page = userRepository.findAllByRole(role, pageable);
+        } else {
+            page = userRepository.findAll(pageable);
+        }
+        return page.map(UserResponseDto::from);
     }
 
     /**
@@ -125,8 +140,9 @@ public class UserService {
     public UserResponseDto updateUser(UUID userId, UserUpdateRequestDto request) {
         User user = findUserById(userId);
 
+        // 허브 변경 시에도 hub-service Feign으로 실제 hubName을 가져온다.
         HubInfo hubInfo = request.getHubId() != null
-                ? new HubInfo(request.getHubId(), "")
+                ? hubProvider.get(request.getHubId())
                 : null;
         CompanyInfo companyInfo = request.getCompanyId() != null
                 ? new CompanyInfo(request.getCompanyId(), "")

--- a/src/main/java/com/loopang/userservice/domain/entity/Courier.java
+++ b/src/main/java/com/loopang/userservice/domain/entity/Courier.java
@@ -17,6 +17,7 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.OneToOne;
 import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
 import jakarta.persistence.Version;
 import java.util.UUID;
 import lombok.AccessLevel;
@@ -28,7 +29,13 @@ import org.hibernate.annotations.SQLRestriction;
 
 @Entity
 @Getter
-@Table(name = "p_courier")
+@Table(
+    name = "p_courier",
+    uniqueConstraints = @UniqueConstraint(
+        name = "uk_courier_hub_type_turn",
+        columnNames = {"hub_id", "delivery_charge_type", "delivery_turn"}
+    )
+)
 @SQLRestriction("deleted_at IS NULL")
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -104,10 +111,18 @@ public class Courier extends BaseUserEntity {
     this.deliveryTurn = turn;
   }
 
-  /** 소속 허브 정보 갱신 (이름 변경 등). 호출자(예: 이벤트 핸들러)가 hub-service의 최신 값을 전달. */
+  /**
+   * 소속 허브의 메타데이터(이름) 갱신 — 동일 허브 내에서만 허용.
+   * <p>허브 이동(다른 hubId)은 deliveryTurn 재배정이 필요하므로 이 메서드로 처리하지 않는다.
+   * 허브 이동 흐름은 별도 도메인 메서드/서비스로 분리해야 한다.</p>
+   */
   public void updateHubInfo(HubInfo newHubInfo) {
     if (newHubInfo == null || newHubInfo.getHubId() == null) {
       throw new BadRequestException("소속 허브 정보는 필수입니다.");
+    }
+    if (this.hubInfo != null && !this.hubInfo.getHubId().equals(newHubInfo.getHubId())) {
+      throw new BadRequestException(
+          "허브 이동은 deliveryTurn 재배정이 필요한 별도 흐름으로 처리해야 합니다.");
     }
     this.hubInfo = newHubInfo;
   }

--- a/src/main/java/com/loopang/userservice/domain/entity/Courier.java
+++ b/src/main/java/com/loopang/userservice/domain/entity/Courier.java
@@ -1,8 +1,12 @@
 package com.loopang.userservice.domain.entity;
 
 import com.loopang.common.domain.BaseUserEntity;
+import com.loopang.common.exception.BadRequestException;
 import com.loopang.userservice.domain.vo.DeliveryChargeType;
+import com.loopang.userservice.domain.vo.HubInfo;
+import com.loopang.userservice.domain.vo.UserType;
 import jakarta.persistence.Column;
+import jakarta.persistence.Embedded;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
@@ -17,6 +21,7 @@ import jakarta.persistence.Version;
 import java.util.UUID;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.SQLRestriction;
@@ -41,6 +46,9 @@ public class Courier extends BaseUserEntity {
   @JoinColumn(name = "user_id", nullable = false)
   private User user;
 
+  @Embedded
+  private HubInfo hubInfo;
+
   @Column(length = 10, nullable = false, name = "delivery_charge_type")
   @Enumerated(EnumType.STRING)
   private DeliveryChargeType type;
@@ -48,7 +56,67 @@ public class Courier extends BaseUserEntity {
   @Column(name = "delivery_turn", nullable = false)
   private int deliveryTurn;
 
-  public void assignDeliveryTurn(Integer turn) {
+  @Builder(access = AccessLevel.PRIVATE)
+  private Courier(User user, HubInfo hubInfo, DeliveryChargeType type, int deliveryTurn) {
+    this.user = user;
+    this.hubInfo = hubInfo;
+    this.type = type;
+    this.deliveryTurn = deliveryTurn;
+  }
+
+  /**
+   * 배송담당자 등록 정적 팩토리.
+   * <p>호출자(CourierService.register)는 이미 user 검증 + HubProvider 조회 + 다음 turn 계산을 마치고
+   * 이 메서드를 호출한다. 이 메서드는 도메인 불변식만 한 번 더 검증한다.</p>
+   */
+  public static Courier register(User user, HubInfo hubInfo, DeliveryChargeType type, int deliveryTurn) {
+    if (user == null) throw new BadRequestException("user는 필수입니다.");
+    if (user.getRole() != UserType.DELIVERY) {
+      throw new BadRequestException("배송담당자 권한(DELIVERY)을 가진 사용자만 등록할 수 있습니다.");
+    }
+    if (!user.isEnabled()) {
+      throw new BadRequestException("승인되지 않았거나 탈퇴한 사용자입니다.");
+    }
+    if (hubInfo == null || hubInfo.getHubId() == null) {
+      throw new BadRequestException("소속 허브 정보는 필수입니다.");
+    }
+    if (type == null) throw new BadRequestException("배송담당자 타입은 필수입니다.");
+    if (deliveryTurn < 1) throw new BadRequestException("배송 순번은 1 이상이어야 합니다.");
+
+    return Courier.builder()
+        .user(user)
+        .hubInfo(hubInfo)
+        .type(type)
+        .deliveryTurn(deliveryTurn)
+        .build();
+  }
+
+  /** 배송담당자 타입 변경 (HUB ↔ COMPANY). 변경 시 deliveryTurn은 호출자가 재할당 책임. */
+  public void changeType(DeliveryChargeType newType, int newTurn) {
+    if (newType == null) throw new BadRequestException("배송담당자 타입은 필수입니다.");
+    if (newTurn < 1) throw new BadRequestException("배송 순번은 1 이상이어야 합니다.");
+    this.type = newType;
+    this.deliveryTurn = newTurn;
+  }
+
+  public void assignDeliveryTurn(int turn) {
+    if (turn < 1) throw new BadRequestException("배송 순번은 1 이상이어야 합니다.");
     this.deliveryTurn = turn;
+  }
+
+  /** 소속 허브 정보 갱신 (이름 변경 등). 호출자(예: 이벤트 핸들러)가 hub-service의 최신 값을 전달. */
+  public void updateHubInfo(HubInfo newHubInfo) {
+    if (newHubInfo == null || newHubInfo.getHubId() == null) {
+      throw new BadRequestException("소속 허브 정보는 필수입니다.");
+    }
+    this.hubInfo = newHubInfo;
+  }
+
+  // TODO: SecurityUtil 전환 후 deletedBy 전달
+  public void softDelete(UUID deletedBy) {
+    if (this.getDeletedAt() != null) {
+      return;
+    }
+    super.delete(deletedBy);
   }
 }

--- a/src/main/java/com/loopang/userservice/domain/exception/CourierDuplicateException.java
+++ b/src/main/java/com/loopang/userservice/domain/exception/CourierDuplicateException.java
@@ -1,0 +1,12 @@
+package com.loopang.userservice.domain.exception;
+
+import com.loopang.common.exception.ConflictException;
+
+import java.util.UUID;
+
+public class CourierDuplicateException extends ConflictException {
+
+    public CourierDuplicateException(UUID userId) {
+        super("이미 등록된 배송담당자입니다. User ID: " + userId);
+    }
+}

--- a/src/main/java/com/loopang/userservice/domain/exception/CourierNotFoundException.java
+++ b/src/main/java/com/loopang/userservice/domain/exception/CourierNotFoundException.java
@@ -1,0 +1,12 @@
+package com.loopang.userservice.domain.exception;
+
+import com.loopang.common.exception.NotFoundException;
+
+import java.util.UUID;
+
+public class CourierNotFoundException extends NotFoundException {
+
+    public CourierNotFoundException(UUID courierId) {
+        super("배송담당자를 찾을 수 없습니다. Courier ID: " + courierId);
+    }
+}

--- a/src/main/java/com/loopang/userservice/domain/repository/CourierRepository.java
+++ b/src/main/java/com/loopang/userservice/domain/repository/CourierRepository.java
@@ -1,4 +1,38 @@
 package com.loopang.userservice.domain.repository;
 
+import com.loopang.userservice.domain.entity.Courier;
+import com.loopang.userservice.domain.vo.DeliveryChargeType;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
 public interface CourierRepository {
+
+  Courier save(Courier courier);
+
+  Optional<Courier> findById(UUID id);
+
+  // 한 user는 한 Courier만 — 중복 등록 방지용
+  Optional<Courier> findByUser_Id(UUID userId);
+
+  Page<Courier> findAll(Pageable pageable);
+
+  // ─── 외부 검색 필터 (MASTER admin) ─────────────────────────────────
+  Page<Courier> findAllByHubInfo_HubIdAndType(UUID hubId, DeliveryChargeType type, Pageable pageable);
+
+  Page<Courier> findAllByHubInfo_HubId(UUID hubId, Pageable pageable);
+
+  Page<Courier> findAllByType(DeliveryChargeType type, Pageable pageable);
+
+  // ─── 내부 호출용 (delivery-service Feign — 라운드로빈 후보 조회) ───
+  // 페이지네이션 없음 — deliveryTurn ASC 정렬
+  List<Courier> findAllByHubInfo_HubIdAndTypeOrderByDeliveryTurnAsc(UUID hubId, DeliveryChargeType type);
+
+  // ─── 등록 시 turn 자동 할당 ───────────────────────────────────────
+  // SELECT MAX(delivery_turn) WHERE hub_id=? AND delivery_charge_type=?
+  // 구현체(JpaCourierRepository)에서 @Query로 명시적 JPQL 작성
+  Optional<Integer> findMaxDeliveryTurn(UUID hubId, DeliveryChargeType type);
 }

--- a/src/main/java/com/loopang/userservice/domain/repository/CourierRepository.java
+++ b/src/main/java/com/loopang/userservice/domain/repository/CourierRepository.java
@@ -13,6 +13,9 @@ public interface CourierRepository {
 
   Courier save(Courier courier);
 
+  // 등록 retry 루프에서 unique 충돌을 즉시 감지하기 위해 명시적 flush가 필요.
+  Courier saveAndFlush(Courier courier);
+
   Optional<Courier> findById(UUID id);
 
   // 한 user는 한 Courier만 — 중복 등록 방지용
@@ -31,8 +34,8 @@ public interface CourierRepository {
   // 페이지네이션 없음 — deliveryTurn ASC 정렬
   List<Courier> findAllByHubInfo_HubIdAndTypeOrderByDeliveryTurnAsc(UUID hubId, DeliveryChargeType type);
 
-  // ─── 등록 시 turn 자동 할당 ───────────────────────────────────────
-  // SELECT MAX(delivery_turn) WHERE hub_id=? AND delivery_charge_type=?
-  // 구현체(JpaCourierRepository)에서 @Query로 명시적 JPQL 작성
-  Optional<Integer> findMaxDeliveryTurn(UUID hubId, DeliveryChargeType type);
+  // ─── 등록 시 turn 자동 할당 (soft-deleted 포함, monotonic) ───────
+  // SELECT COALESCE(MAX(delivery_turn), 0) FROM p_courier WHERE hub_id=? AND delivery_charge_type=?
+  // 구현체(JpaCourierRepository)에서 native query로 @SQLRestriction 우회
+  int findMaxDeliveryTurnIncludingDeleted(UUID hubId, String type);
 }

--- a/src/main/java/com/loopang/userservice/domain/repository/UserRepository.java
+++ b/src/main/java/com/loopang/userservice/domain/repository/UserRepository.java
@@ -1,9 +1,11 @@
 package com.loopang.userservice.domain.repository;
 
 import com.loopang.userservice.domain.entity.User;
+import com.loopang.userservice.domain.vo.UserType;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -18,4 +20,11 @@ public interface UserRepository {
   boolean existsByEmail(String email);
 
   boolean existsBySlackId(String slackId);
+
+  // 내부 서비스 호출용 — role 단일 필터
+  List<User> findAllByRole(UserType role);
+
+  // 내부 서비스 호출용 — role + 소속 허브(hubInfo.hubId) 복합 필터
+  // Spring Data JPA가 underscore 표기로 embedded 경로(hubInfo.hubId)를 명시적으로 해석
+  List<User> findAllByRoleAndHubInfo_HubId(UserType role, UUID hubId);
 }

--- a/src/main/java/com/loopang/userservice/domain/repository/UserRepository.java
+++ b/src/main/java/com/loopang/userservice/domain/repository/UserRepository.java
@@ -21,15 +21,18 @@ public interface UserRepository {
 
   boolean existsBySlackId(String slackId);
 
-  // 내부 서비스 호출용 — role 단일 필터 (페이지네이션 없음)
+  // 내부 서비스 호출용 — 단일/복합 필터 (페이지네이션 없음)
   List<User> findAllByRole(UserType role);
 
-  // 내부 서비스 호출용 — role + 소속 허브(hubInfo.hubId) 복합 필터 (페이지네이션 없음)
+  List<User> findAllByHubInfo_HubId(UUID hubId);
+
   // Spring Data JPA가 underscore 표기로 embedded 경로(hubInfo.hubId)를 명시적으로 해석
   List<User> findAllByRoleAndHubInfo_HubId(UserType role, UUID hubId);
 
   // 외부 검색 필터용 — 페이지네이션 버전 (MASTER admin UI에서 사용)
   Page<User> findAllByRole(UserType role, Pageable pageable);
+
+  Page<User> findAllByHubInfo_HubId(UUID hubId, Pageable pageable);
 
   Page<User> findAllByRoleAndHubInfo_HubId(UserType role, UUID hubId, Pageable pageable);
 }

--- a/src/main/java/com/loopang/userservice/domain/repository/UserRepository.java
+++ b/src/main/java/com/loopang/userservice/domain/repository/UserRepository.java
@@ -21,10 +21,15 @@ public interface UserRepository {
 
   boolean existsBySlackId(String slackId);
 
-  // 내부 서비스 호출용 — role 단일 필터
+  // 내부 서비스 호출용 — role 단일 필터 (페이지네이션 없음)
   List<User> findAllByRole(UserType role);
 
-  // 내부 서비스 호출용 — role + 소속 허브(hubInfo.hubId) 복합 필터
+  // 내부 서비스 호출용 — role + 소속 허브(hubInfo.hubId) 복합 필터 (페이지네이션 없음)
   // Spring Data JPA가 underscore 표기로 embedded 경로(hubInfo.hubId)를 명시적으로 해석
   List<User> findAllByRoleAndHubInfo_HubId(UserType role, UUID hubId);
+
+  // 외부 검색 필터용 — 페이지네이션 버전 (MASTER admin UI에서 사용)
+  Page<User> findAllByRole(UserType role, Pageable pageable);
+
+  Page<User> findAllByRoleAndHubInfo_HubId(UserType role, UUID hubId, Pageable pageable);
 }

--- a/src/main/java/com/loopang/userservice/domain/vo/HubInfo.java
+++ b/src/main/java/com/loopang/userservice/domain/vo/HubInfo.java
@@ -13,10 +13,12 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 public class HubInfo {
 
+  public static final int MAX_HUB_NAME_LENGTH = 50;
+
   @Column(name = "hub_id", nullable = false)
   private UUID hubId;
 
-  @Column(length = 50, name = "hub_name", nullable = false)
+  @Column(length = MAX_HUB_NAME_LENGTH, name = "hub_name", nullable = false)
   private String hubName;
 
   // TODO: HubProvider 구현 후 이 생성자 사용

--- a/src/main/java/com/loopang/userservice/infrastructure/feign/HubFeignClient.java
+++ b/src/main/java/com/loopang/userservice/infrastructure/feign/HubFeignClient.java
@@ -1,0 +1,16 @@
+package com.loopang.userservice.infrastructure.feign;
+
+import com.loopang.common.response.CommonResponse;
+import com.loopang.userservice.infrastructure.feign.dto.HubData;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+
+import java.util.UUID;
+
+@FeignClient(name = "hub-service")
+public interface HubFeignClient {
+
+    @GetMapping("/api/hubs/{hubId}")
+    CommonResponse<HubData> getHub(@PathVariable("hubId") UUID hubId);
+}

--- a/src/main/java/com/loopang/userservice/infrastructure/feign/HubProviderImpl.java
+++ b/src/main/java/com/loopang/userservice/infrastructure/feign/HubProviderImpl.java
@@ -1,0 +1,49 @@
+package com.loopang.userservice.infrastructure.feign;
+
+import com.loopang.common.exception.NotFoundException;
+import com.loopang.common.response.CommonResponse;
+import com.loopang.userservice.domain.service.HubProvider;
+import com.loopang.userservice.domain.vo.HubInfo;
+import com.loopang.userservice.infrastructure.feign.dto.HubData;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+import java.util.UUID;
+
+/**
+ * hub-service Feign 호출로 허브 이름을 가져와 HubInfo VO를 생성한다.
+ *
+ * <p>회원가입/수정 시 호출자가 hubId만 알면 hub-service에 위임해 정확한 hubName을 채우도록 한다.
+ * 이전엔 빈 문자열("")로 저장돼 응답/알림에서 허브명이 비어 보이는 문제가 있었다.</p>
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class HubProviderImpl implements HubProvider {
+
+    private final HubFeignClient hubFeignClient;
+
+    @Override
+    public HubInfo get(UUID hubId) {
+        if (hubId == null) {
+            return null;
+        }
+
+        try {
+            CommonResponse<HubData> response = hubFeignClient.getHub(hubId);
+            HubData data = response != null ? response.getData() : null;
+
+            if (data == null || data.hubId() == null || data.name() == null || data.name().isBlank()) {
+                throw new NotFoundException("소속 허브를 찾을 수 없습니다. hubId=" + hubId);
+            }
+
+            return new HubInfo(data.hubId(), data.name());
+        } catch (NotFoundException e) {
+            throw e;
+        } catch (Exception e) {
+            log.error("[HubProvider] hub-service 호출 실패 hubId={}", hubId, e);
+            throw new NotFoundException("소속 허브 조회에 실패했습니다. hubId=" + hubId);
+        }
+    }
+}

--- a/src/main/java/com/loopang/userservice/infrastructure/feign/HubProviderImpl.java
+++ b/src/main/java/com/loopang/userservice/infrastructure/feign/HubProviderImpl.java
@@ -72,9 +72,13 @@ public class HubProviderImpl implements HubProvider {
         }
 
         // 200 응답인데 필수 필드가 비어 있는 건 hub-service의 계약 위반(payload 깨짐).
-        // "허브 없음"이 아니라 원격 서비스 오동작이므로 500으로 분리한다.
-        if (data.hubId() == null || data.name() == null || data.name().isBlank()) {
-            log.error("[HubProvider] 응답 payload 누락: hubId={}, data={}", hubId, data);
+        // hubName 50자 초과도 여기서 같이 잡는다 — HubInfo VO 생성자/저장 단계까지 새어나가면
+        // "허브 서비스 응답이 올바르지 않습니다"라는 의도한 분류 대신 다른 오류로 분류돼 진단이 어려워짐.
+        if (data.hubId() == null
+                || data.name() == null
+                || data.name().isBlank()
+                || data.name().length() > HubInfo.MAX_HUB_NAME_LENGTH) {
+            log.error("[HubProvider] 응답 payload 이상: hubId={}, data={}", hubId, data);
             throw new InternalServerException(
                     "허브 서비스 응답이 올바르지 않습니다. hubId=" + hubId);
         }

--- a/src/main/java/com/loopang/userservice/infrastructure/feign/HubProviderImpl.java
+++ b/src/main/java/com/loopang/userservice/infrastructure/feign/HubProviderImpl.java
@@ -63,8 +63,17 @@ public class HubProviderImpl implements HubProvider {
 
         HubData data = response != null ? response.getData() : null;
 
-        if (data == null || data.hubId() == null || data.name() == null || data.name().isBlank()) {
+        // 200 응답인데 data 자체가 null → "허브 없음"으로 본다 (404)
+        if (data == null) {
             throw new NotFoundException("소속 허브를 찾을 수 없습니다. hubId=" + hubId);
+        }
+
+        // 200 응답인데 필수 필드가 비어 있는 건 hub-service의 계약 위반(payload 깨짐).
+        // "허브 없음"이 아니라 원격 서비스 오동작이므로 500으로 분리한다.
+        if (data.hubId() == null || data.name() == null || data.name().isBlank()) {
+            log.error("[HubProvider] 응답 payload 누락: hubId={}, data={}", hubId, data);
+            throw new InternalServerException(
+                    "허브 서비스 응답이 올바르지 않습니다. hubId=" + hubId);
         }
 
         // 응답의 hubId가 요청 hubId와 일치하는지 검증 — 업스트림 오동작 방어

--- a/src/main/java/com/loopang/userservice/infrastructure/feign/HubProviderImpl.java
+++ b/src/main/java/com/loopang/userservice/infrastructure/feign/HubProviderImpl.java
@@ -1,10 +1,12 @@
 package com.loopang.userservice.infrastructure.feign;
 
+import com.loopang.common.exception.InternalServerException;
 import com.loopang.common.exception.NotFoundException;
 import com.loopang.common.response.CommonResponse;
 import com.loopang.userservice.domain.service.HubProvider;
 import com.loopang.userservice.domain.vo.HubInfo;
 import com.loopang.userservice.infrastructure.feign.dto.HubData;
+import feign.FeignException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
@@ -14,8 +16,17 @@ import java.util.UUID;
 /**
  * hub-service Feign 호출로 허브 이름을 가져와 HubInfo VO를 생성한다.
  *
- * <p>회원가입/수정 시 호출자가 hubId만 알면 hub-service에 위임해 정확한 hubName을 채우도록 한다.
+ * <p>회원가입/수정/Courier 등록 시 호출자가 hubId만 알면 hub-service에 위임해 정확한 hubName을 채우도록 한다.
  * 이전엔 빈 문자열("")로 저장돼 응답/알림에서 허브명이 비어 보이는 문제가 있었다.</p>
+ *
+ * <p>오류 분리:
+ * <ul>
+ *   <li>404 / 응답 데이터 누락 → {@link NotFoundException} (허브 자체가 없음)</li>
+ *   <li>5xx / 타임아웃 / 연결 실패 → {@link InternalServerException} (원격 서비스 장애)</li>
+ * </ul>
+ * 모든 원격 호출 실패를 NotFoundException으로 일괄 변환하면 운영 모니터링에서
+ * "허브 없음"과 "hub-service 장애"를 구분할 수 없어 장애 탐지가 늦어지므로 분리한다.
+ * </p>
  */
 @Slf4j
 @Component
@@ -30,20 +41,39 @@ public class HubProviderImpl implements HubProvider {
             return null;
         }
 
+        CommonResponse<HubData> response;
         try {
-            CommonResponse<HubData> response = hubFeignClient.getHub(hubId);
-            HubData data = response != null ? response.getData() : null;
-
-            if (data == null || data.hubId() == null || data.name() == null || data.name().isBlank()) {
-                throw new NotFoundException("소속 허브를 찾을 수 없습니다. hubId=" + hubId);
-            }
-
-            return new HubInfo(data.hubId(), data.name());
-        } catch (NotFoundException e) {
-            throw e;
+            response = hubFeignClient.getHub(hubId);
+        } catch (FeignException.NotFound e) {
+            // hub-service가 명시적으로 404 반환 → 진짜 "허브 없음"
+            log.warn("[HubProvider] 허브 없음 (404): hubId={}", hubId);
+            throw new NotFoundException("소속 허브를 찾을 수 없습니다. hubId=" + hubId);
+        } catch (FeignException e) {
+            // 5xx, 4xx (404 외), 타임아웃, 연결 실패 등 — 원격 서비스 장애
+            log.error("[HubProvider] hub-service 원격 호출 실패: hubId={}, status={}, message={}",
+                    hubId, e.status(), e.getMessage(), e);
+            throw new InternalServerException(
+                    "허브 서비스 호출에 실패했습니다. hubId=" + hubId);
         } catch (Exception e) {
-            log.error("[HubProvider] hub-service 호출 실패 hubId={}", hubId, e);
-            throw new NotFoundException("소속 허브 조회에 실패했습니다. hubId=" + hubId);
+            // 응답 직렬화 등 예상 못한 예외
+            log.error("[HubProvider] hub-service 호출 중 예외 발생: hubId={}", hubId, e);
+            throw new InternalServerException(
+                    "허브 서비스 호출 중 오류가 발생했습니다. hubId=" + hubId);
         }
+
+        HubData data = response != null ? response.getData() : null;
+
+        if (data == null || data.hubId() == null || data.name() == null || data.name().isBlank()) {
+            throw new NotFoundException("소속 허브를 찾을 수 없습니다. hubId=" + hubId);
+        }
+
+        // 응답의 hubId가 요청 hubId와 일치하는지 검증 — 업스트림 오동작 방어
+        if (!hubId.equals(data.hubId())) {
+            log.error("[HubProvider] 응답 hubId 불일치: requested={}, returned={}", hubId, data.hubId());
+            throw new InternalServerException(
+                    "허브 서비스 응답이 올바르지 않습니다. hubId=" + hubId);
+        }
+
+        return new HubInfo(data.hubId(), data.name());
     }
 }

--- a/src/main/java/com/loopang/userservice/infrastructure/feign/HubProviderImpl.java
+++ b/src/main/java/com/loopang/userservice/infrastructure/feign/HubProviderImpl.java
@@ -1,5 +1,6 @@
 package com.loopang.userservice.infrastructure.feign;
 
+import com.loopang.common.exception.BadRequestException;
 import com.loopang.common.exception.InternalServerException;
 import com.loopang.common.exception.NotFoundException;
 import com.loopang.common.response.CommonResponse;
@@ -37,8 +38,10 @@ public class HubProviderImpl implements HubProvider {
 
     @Override
     public HubInfo get(UUID hubId) {
+        // null 반환은 호출자(CourierService 등)가 non-null 가정으로 NPE 위험.
+        // HubProvider 계약은 non-nullable — 명시적 예외로 끊는다.
         if (hubId == null) {
-            return null;
+            throw new BadRequestException("hubId는 필수입니다.");
         }
 
         CommonResponse<HubData> response;

--- a/src/main/java/com/loopang/userservice/infrastructure/feign/dto/HubData.java
+++ b/src/main/java/com/loopang/userservice/infrastructure/feign/dto/HubData.java
@@ -1,0 +1,15 @@
+package com.loopang.userservice.infrastructure.feign.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+import java.util.UUID;
+
+/**
+ * hub-service GET /api/hubs/{hubId} 응답 데이터 — HubInfo VO 생성에 필요한 최소 필드만 포함.
+ * 추가 필드(capacity, address 등)는 무시한다.
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record HubData(
+        UUID hubId,
+        String name
+) {}

--- a/src/main/java/com/loopang/userservice/infrastructure/repository/JpaCourierRepository.java
+++ b/src/main/java/com/loopang/userservice/infrastructure/repository/JpaCourierRepository.java
@@ -2,25 +2,31 @@ package com.loopang.userservice.infrastructure.repository;
 
 import com.loopang.userservice.domain.entity.Courier;
 import com.loopang.userservice.domain.repository.CourierRepository;
-import com.loopang.userservice.domain.vo.DeliveryChargeType;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
-import java.util.Optional;
 import java.util.UUID;
 
 @Repository
 public interface JpaCourierRepository extends JpaRepository<Courier, UUID>, CourierRepository {
 
     /**
-     * 같은 허브 + 같은 타입의 현재 max(deliveryTurn) 조회.
-     * Spring Data JPA 메서드 네이밍으로 MAX 집계가 깔끔히 표현되지 않아 명시적 JPQL 사용.
-     * @SQLRestriction("deleted_at IS NULL")가 자동 적용돼 soft-deleted 행은 제외됨.
+     * 같은 허브 + 같은 타입의 현재 max(deliveryTurn) 조회 — soft-deleted 행 포함.
+     *
+     * <p>JPQL은 {@code @SQLRestriction("deleted_at IS NULL")}이 자동 적용되어 soft-deleted 행을 제외하지만,
+     * 그러면 soft-deleted courier가 가진 turn 자리가 비어 있는 것처럼 보여 새 등록 시 같은 turn으로
+     * 배정 → unique 제약(`uk_courier_hub_type_turn`)과 충돌해 retry 루프가 무한 실패한다.</p>
+     *
+     * <p>따라서 turn 할당은 monotonic — 죽은 row까지 포함한 max + 1로 가야 한다.
+     * native query로 {@code @SQLRestriction}을 우회한다.</p>
      */
-    @Query("SELECT MAX(c.deliveryTurn) FROM Courier c " +
-            "WHERE c.hubInfo.hubId = :hubId AND c.type = :type")
-    Optional<Integer> findMaxDeliveryTurn(@Param("hubId") UUID hubId,
-                                          @Param("type") DeliveryChargeType type);
+    @Query(value = """
+            SELECT COALESCE(MAX(delivery_turn), 0)
+            FROM p_courier
+            WHERE hub_id = :hubId AND delivery_charge_type = :type
+            """, nativeQuery = true)
+    int findMaxDeliveryTurnIncludingDeleted(@Param("hubId") UUID hubId,
+                                            @Param("type") String type);
 }

--- a/src/main/java/com/loopang/userservice/infrastructure/repository/JpaCourierRepository.java
+++ b/src/main/java/com/loopang/userservice/infrastructure/repository/JpaCourierRepository.java
@@ -2,11 +2,25 @@ package com.loopang.userservice.infrastructure.repository;
 
 import com.loopang.userservice.domain.entity.Courier;
 import com.loopang.userservice.domain.repository.CourierRepository;
+import com.loopang.userservice.domain.vo.DeliveryChargeType;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
 import java.util.UUID;
 
 @Repository
 public interface JpaCourierRepository extends JpaRepository<Courier, UUID>, CourierRepository {
+
+    /**
+     * 같은 허브 + 같은 타입의 현재 max(deliveryTurn) 조회.
+     * Spring Data JPA 메서드 네이밍으로 MAX 집계가 깔끔히 표현되지 않아 명시적 JPQL 사용.
+     * @SQLRestriction("deleted_at IS NULL")가 자동 적용돼 soft-deleted 행은 제외됨.
+     */
+    @Query("SELECT MAX(c.deliveryTurn) FROM Courier c " +
+            "WHERE c.hubInfo.hubId = :hubId AND c.type = :type")
+    Optional<Integer> findMaxDeliveryTurn(@Param("hubId") UUID hubId,
+                                          @Param("type") DeliveryChargeType type);
 }

--- a/src/main/java/com/loopang/userservice/presentation/controller/CourierController.java
+++ b/src/main/java/com/loopang/userservice/presentation/controller/CourierController.java
@@ -1,0 +1,91 @@
+package com.loopang.userservice.presentation.controller;
+
+import com.loopang.common.exception.ForbiddenException;
+import com.loopang.common.response.CommonResponse;
+import com.loopang.common.response.PageInfo;
+import com.loopang.userservice.application.service.CourierService;
+import com.loopang.userservice.domain.vo.DeliveryChargeType;
+import com.loopang.userservice.domain.vo.UserType;
+import com.loopang.userservice.presentation.dto.CourierCreateRequestDto;
+import com.loopang.userservice.presentation.dto.CourierUpdateRequestDto;
+import com.loopang.userservice.presentation.dto.response.CourierResponseDto;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+import java.util.UUID;
+
+@RestController
+@RequestMapping("/api/couriers")
+@RequiredArgsConstructor
+public class CourierController {
+
+    private final CourierService courierService;
+
+    @PostMapping
+    @ResponseStatus(HttpStatus.CREATED)
+    public CommonResponse<CourierResponseDto> register(
+            @RequestHeader("X-User-Role") String userRole,
+            @Valid @RequestBody CourierCreateRequestDto request) {
+        checkMaster(userRole);
+        return CommonResponse.success(courierService.register(request), "배송담당자 등록에 성공했습니다.");
+    }
+
+    @GetMapping("/{courierId}")
+    public CommonResponse<CourierResponseDto> getCourier(
+            @PathVariable UUID courierId,
+            @RequestHeader("X-User-Role") String userRole) {
+        checkMaster(userRole);
+        return CommonResponse.success(courierService.getCourier(courierId), "배송담당자 조회에 성공했습니다.");
+    }
+
+    @GetMapping
+    public CommonResponse<List<CourierResponseDto>> getCouriers(
+            Pageable pageable,
+            @RequestHeader("X-User-Role") String userRole,
+            @RequestParam(required = false) UUID hubId,
+            @RequestParam(required = false) DeliveryChargeType type) {
+        checkMaster(userRole);
+        Page<CourierResponseDto> page = courierService.getCouriers(hubId, type, pageable);
+        return CommonResponse.success(page.getContent(), "배송담당자 목록 조회에 성공했습니다.", PageInfo.from(page));
+    }
+
+    @PatchMapping("/{courierId}")
+    public CommonResponse<CourierResponseDto> updateCourier(
+            @PathVariable UUID courierId,
+            @RequestHeader("X-User-Role") String userRole,
+            @Valid @RequestBody CourierUpdateRequestDto request) {
+        checkMaster(userRole);
+        return CommonResponse.success(courierService.updateCourier(courierId, request), "배송담당자 정보가 수정되었습니다.");
+    }
+
+    @DeleteMapping("/{courierId}")
+    public CommonResponse<Void> deleteCourier(
+            @PathVariable UUID courierId,
+            @RequestHeader("X-User-UUID") UUID requesterId,
+            @RequestHeader("X-User-Role") String userRole) {
+        checkMaster(userRole);
+        courierService.deleteCourier(courierId, requesterId);
+        return CommonResponse.success(null, "배송담당자가 삭제되었습니다.");
+    }
+
+    private void checkMaster(String userRole) {
+        if (!UserType.MASTER.toRole().equals(userRole)) {
+            throw new ForbiddenException("마스터 관리자만 수행할 수 있는 작업입니다.");
+        }
+    }
+}

--- a/src/main/java/com/loopang/userservice/presentation/controller/InternalCourierController.java
+++ b/src/main/java/com/loopang/userservice/presentation/controller/InternalCourierController.java
@@ -1,0 +1,61 @@
+package com.loopang.userservice.presentation.controller;
+
+import com.loopang.common.response.CommonResponse;
+import com.loopang.userservice.application.service.CourierService;
+import com.loopang.userservice.domain.vo.DeliveryChargeType;
+import com.loopang.userservice.presentation.dto.response.CourierResponseDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * 내부 서비스 호출 전용 배송담당자 조회 컨트롤러.
+ *
+ * <p>delivery-service 등 다른 MSA 컴포넌트가 Feign으로 호출한다.
+ * 권한 검증이나 페이지네이션이 없으며, 운영 환경에서는 ALB/SG로 외부 노출을 차단해야 한다.</p>
+ *
+ * <p>외부 노출 API는 {@link CourierController}이며 MASTER 권한이 적용된다.</p>
+ */
+@RestController
+@RequestMapping("/internal/couriers")
+@RequiredArgsConstructor
+public class InternalCourierController {
+
+    private final CourierService courierService;
+
+    /**
+     * 단건 조회 — 배송 알림 시 courier 이름/슬랙 ID 등 정보 조회용.
+     */
+    @GetMapping("/{courierId}")
+    public CommonResponse<CourierResponseDto> getCourier(@PathVariable UUID courierId) {
+        return CommonResponse.success(
+                courierService.getInternalCourier(courierId),
+                "배송담당자 조회에 성공했습니다."
+        );
+    }
+
+    /**
+     * 라운드로빈 후보 리스트 — delivery-service가 segment별 배정 시 호출.
+     * <ul>
+     *   <li>특정 허브 + 특정 타입의 active courier만 반환</li>
+     *   <li>deliveryTurn ASC 정렬</li>
+     *   <li>소속 user가 enabled=true인 경우만</li>
+     *   <li>페이지네이션 없음 (허브당 ~10명)</li>
+     * </ul>
+     */
+    @GetMapping
+    public CommonResponse<List<CourierResponseDto>> findCandidates(
+            @RequestParam UUID hubId,
+            @RequestParam DeliveryChargeType type) {
+        return CommonResponse.success(
+                courierService.findCandidatesForAssignment(hubId, type),
+                "배송담당자 후보 조회에 성공했습니다."
+        );
+    }
+}

--- a/src/main/java/com/loopang/userservice/presentation/controller/InternalUserController.java
+++ b/src/main/java/com/loopang/userservice/presentation/controller/InternalUserController.java
@@ -1,0 +1,59 @@
+package com.loopang.userservice.presentation.controller;
+
+import com.loopang.common.response.CommonResponse;
+import com.loopang.userservice.application.service.UserService;
+import com.loopang.userservice.domain.vo.UserType;
+import com.loopang.userservice.presentation.dto.response.UserResponseDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * 내부 서비스 호출 전용 사용자 조회 컨트롤러.
+ *
+ * <p>외부 클라이언트는 호출하지 않는다. delivery-service 등 다른 MSA 컴포넌트가
+ * Feign으로 호출하며, Keycloak JWT 검증이나 X-User-Role 헤더 검증을 거치지 않는다.
+ * 운영 환경에서는 ALB Listener Rule 또는 Security Group으로 외부에서 {@code /internal/**}을
+ * 직접 때리는 트래픽을 차단해야 한다 (gateway/인프라 정책).</p>
+ *
+ * <p>외부 노출 API는 {@link UserController}이며 권한 검사가 적용된다.</p>
+ */
+@RestController
+@RequestMapping("/internal/users")
+@RequiredArgsConstructor
+public class InternalUserController {
+
+    private final UserService userService;
+
+    /**
+     * 단건 조회 — Courier 등록 시 user 존재/role/hubId 검증용.
+     */
+    @GetMapping("/{userId}")
+    public CommonResponse<UserResponseDto> getUser(@PathVariable UUID userId) {
+        return CommonResponse.success(
+                userService.getInternalUser(userId),
+                "사용자 조회에 성공했습니다."
+        );
+    }
+
+    /**
+     * 리스트 조회 — 특정 role의 사용자, 선택적으로 소속 허브로 필터링.
+     * 페이지네이션 없음 (허브당 최대 ~20명 가정).
+     * enabled=true인 사용자만 반환.
+     */
+    @GetMapping
+    public CommonResponse<List<UserResponseDto>> searchUsers(
+            @RequestParam UserType role,
+            @RequestParam(required = false) UUID hubId) {
+        return CommonResponse.success(
+                userService.searchInternal(role, hubId),
+                "사용자 목록 조회에 성공했습니다."
+        );
+    }
+}

--- a/src/main/java/com/loopang/userservice/presentation/controller/UserController.java
+++ b/src/main/java/com/loopang/userservice/presentation/controller/UserController.java
@@ -62,9 +62,11 @@ public class UserController {
     @GetMapping
     public CommonResponse<List<UserResponseDto>> getUsers(
             Pageable pageable,
-            @RequestHeader("X-User-Role") String userRole) {
+            @RequestHeader("X-User-Role") String userRole,
+            @RequestParam(required = false) UserType role,
+            @RequestParam(required = false) UUID hubId) {
         checkMaster(userRole);
-        Page<UserResponseDto> page = userService.getUsers(pageable);
+        Page<UserResponseDto> page = userService.getUsers(role, hubId, pageable);
         return CommonResponse.success(page.getContent(), "사용자 목록 조회에 성공했습니다.", PageInfo.from(page));
     }
 

--- a/src/main/java/com/loopang/userservice/presentation/dto/CourierCreateRequestDto.java
+++ b/src/main/java/com/loopang/userservice/presentation/dto/CourierCreateRequestDto.java
@@ -1,0 +1,21 @@
+package com.loopang.userservice.presentation.dto;
+
+import com.loopang.userservice.domain.vo.DeliveryChargeType;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.UUID;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class CourierCreateRequestDto {
+
+    @NotNull(message = "userId는 필수입니다.")
+    private UUID userId;
+
+    @NotNull(message = "deliveryChargeType은 필수입니다. (HUB 또는 COMPANY)")
+    private DeliveryChargeType deliveryChargeType;
+}

--- a/src/main/java/com/loopang/userservice/presentation/dto/CourierUpdateRequestDto.java
+++ b/src/main/java/com/loopang/userservice/presentation/dto/CourierUpdateRequestDto.java
@@ -1,0 +1,14 @@
+package com.loopang.userservice.presentation.dto;
+
+import com.loopang.userservice.domain.vo.DeliveryChargeType;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class CourierUpdateRequestDto {
+
+    private DeliveryChargeType deliveryChargeType;
+}

--- a/src/main/java/com/loopang/userservice/presentation/dto/response/CourierResponseDto.java
+++ b/src/main/java/com/loopang/userservice/presentation/dto/response/CourierResponseDto.java
@@ -1,0 +1,51 @@
+package com.loopang.userservice.presentation.dto.response;
+
+import com.loopang.userservice.domain.entity.Courier;
+import com.loopang.userservice.domain.vo.DeliveryChargeType;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Getter
+@Builder
+public class CourierResponseDto {
+
+    private UUID courierId;
+    private UUID userId;
+    private String userName;
+    private String email;
+    private String slackId;
+    private UUID hubId;
+    private String hubName;
+    private DeliveryChargeType deliveryChargeType;
+    private int deliveryTurn;
+    private boolean enabled;
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+
+    public static CourierResponseDto from(Courier courier) {
+        var builder = CourierResponseDto.builder()
+                .courierId(courier.getId())
+                .deliveryChargeType(courier.getType())
+                .deliveryTurn(courier.getDeliveryTurn())
+                .createdAt(courier.getCreatedAt())
+                .updatedAt(courier.getUpdatedAt());
+
+        if (courier.getUser() != null) {
+            builder.userId(courier.getUser().getId())
+                    .userName(courier.getUser().getName())
+                    .email(courier.getUser().getEmail())
+                    .slackId(courier.getUser().getSlackId())
+                    .enabled(courier.getUser().isEnabled());
+        }
+
+        if (courier.getHubInfo() != null) {
+            builder.hubId(courier.getHubInfo().getHubId())
+                    .hubName(courier.getHubInfo().getHubName());
+        }
+
+        return builder.build();
+    }
+}


### PR DESCRIPTION
## 📌 작업 유형
- [x] 신규 기능 추가
- [x] 도메인 보강

## ✅ 작업 내용

### Internal User API
- `GET /internal/users/{userId}` 단건 조회 (권한 검증 없음, 내부 호출용)
- `GET /internal/users?role=&hubId=` 리스트 조회 (페이지네이션 없음, enabled=true 필터)

### 외부 검색 필터
- `GET /api/users?role=&hubId=` MASTER admin 검색

### HubProvider Feign 연동
- 회원가입/수정 시 hub-service Feign으로 hubName 실제 값 채움 (이전엔 빈 문자열)
- common 0.0.4 → 0.0.5-SNAPSHOT 업데이트

### Courier 도메인 완성
- 기존 user-service의 Courier 스켈레톤 완성 — user-service가 Courier owner로 결정
- Courier 엔티티에 \`@Embedded HubInfo\` 추가 (User처럼 자기 hub 직접 보유 → N+1 회피)
- \`Courier.register()\` 정적 팩토리 + 도메인 검증 (role=DELIVERY, enabled, hubInfo, type, turn)
- CourierService: register, CRUD, findCandidatesForAssignment (라운드로빈 후보)
- CourierController: \`/api/couriers\` MASTER admin CRUD
- InternalCourierController: \`/internal/couriers\` delivery-service Feign용
- deliveryTurn 자동 할당 (max+1)
- type 변경 시 새 turn 자동 재할당

## 🧪 테스트 / 확인 방법
- [x] 로컬 빌드 성공 (BUILD SUCCESSFUL)
- [ ] 로컬 통합 테스트 (delivery-service 측 작업 후 함께)

## ⚠️ 영향 범위
- [x] API 신규 추가
- [x] DB 스키마 변경 (Courier 엔티티에 hub_id, hub_name 컬럼 추가)
- [x] 외부 서비스 의존성 추가 (hub-service Feign)
- [x] common 버전 업데이트 (0.0.4 → 0.0.5)

## 👀 리뷰 포인트
- Courier 등록 시 HubProvider로 최신 hub 정보 fetch하는 흐름
- Spring Data JPA underscore 표기로 embedded 경로 명시 (\`HubInfo_HubId\`)
- 라운드로빈 상태 관리는 delivery-service 책임 — user-service는 후보 리스트만 제공
- \`/internal/**\` 외부 노출 차단은 운영 단계에서 ALB/SG로 처리 필요

## 🤝 연관 작업
- gateway PR (feat/internal-users-routing): \`/internal/users/**, /api/couriers/**, /internal/couriers/**\` 라우팅 추가
- delivery-service: 자체 Courier 엔티티 폐기 + CourierFeignClient + 배정 로직 (현빈님 작업)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 배송기사 관리: 등록·조회·수정·삭제 및 내부 라운드로빈 후보 조회 API 추가
  * 사용자 목록 조회에 역할(role)·허브(hubId) 필터링 추가
  * 허브 서비스 연동 검증 강화(허브 조회/응답 유효성 검사)
  * 배송기사 순번 자동 배정 개선(동시성 경합 처리 및 재시도)

* **Chores**
  * 공통 라이브러리 버전 업데이트
  * .gitignore 갱신

* **Documentation**
  * README에 유저·배송기사 도메인, 외부/내부 API 및 처리 흐름 문서화
<!-- end of auto-generated comment: release notes by coderabbit.ai -->