### PR TITLE
feat: 사용자 변경 이벤트 발행 (user-update-topic)

### DIFF
--- a/src/main/java/com/loopang/userservice/application/service/UserService.java
+++ b/src/main/java/com/loopang/userservice/application/service/UserService.java
@@ -2,6 +2,7 @@ package com.loopang.userservice.application.service;
 
 import com.loopang.userservice.domain.entity.User;
 import com.loopang.common.exception.ForbiddenException;
+import com.loopang.userservice.domain.event.UserEvents;
 import com.loopang.userservice.domain.exception.UserEmailDuplicateException;
 import com.loopang.userservice.domain.exception.UserNotFoundException;
 import com.loopang.userservice.domain.exception.UserSlackIdDuplicateException;
@@ -36,6 +37,7 @@ public class UserService {
     private final UserRepository userRepository;
     private final IdentityProvider identityProvider;
     private final HubProvider hubProvider;
+    private final UserEvents userEvents;
 
     @Transactional
     public SignupResponseDto signup(SignupRequestDto request) {
@@ -152,7 +154,7 @@ public class UserService {
     }
 
     @Transactional
-    public UserResponseDto updateUser(UUID userId, UserUpdateRequestDto request) {
+    public UserResponseDto updateUser(UUID userId, UserUpdateRequestDto request, UUID requesterId) {
         User user = findUserById(userId);
 
         // 허브 변경 시에도 hub-service Feign으로 실제 hubName을 가져온다.
@@ -165,6 +167,9 @@ public class UserService {
 
         user.update(request.getName(), request.getSlackId(), request.getRole(),
                 hubInfo, companyInfo, request.getApproved());
+
+        // 변경 이벤트 발행 (Outbox) — company-service 등 구독자가 사용자/담당자 정보 동기화에 사용
+        userEvents.userChanged(user, requesterId);
 
         return UserResponseDto.from(user);
     }

--- a/src/main/java/com/loopang/userservice/domain/event/ManagerUpdatedEvent.java
+++ b/src/main/java/com/loopang/userservice/domain/event/ManagerUpdatedEvent.java
@@ -1,0 +1,26 @@
+package com.loopang.userservice.domain.event;
+
+import com.loopang.userservice.domain.entity.User;
+
+import java.util.UUID;
+
+/**
+ * 사용자 변경 이벤트 페이로드.
+ *
+ * <p>{@code user-update-topic}으로 발행되며, company-service 등 구독자가
+ * 자기 도메인의 담당자(manager) 정보 동기화에 사용한다.</p>
+ *
+ * <p>필드 구성은 단비님(company-service) 측 {@code ManagerUpdatedEvent}와 동일.
+ * JSON 키 기준으로 deserialize되므로 필드명을 그대로 맞춘다 (managerId/managerName).
+ * user 도메인 관점에선 userId/userName이 자연스럽지만, 호출자(company-service)가
+ * 이미 manager 용어로 정의해놨으므로 우리가 맞춘다.</p>
+ */
+public record ManagerUpdatedEvent(
+        UUID managerId,
+        String managerName,
+        UUID updatedBy
+) {
+    public static ManagerUpdatedEvent from(User user, UUID updatedBy) {
+        return new ManagerUpdatedEvent(user.getId(), user.getName(), updatedBy);
+    }
+}

--- a/src/main/java/com/loopang/userservice/domain/event/UserEvents.java
+++ b/src/main/java/com/loopang/userservice/domain/event/UserEvents.java
@@ -1,0 +1,22 @@
+package com.loopang.userservice.domain.event;
+
+import com.loopang.userservice.domain.entity.User;
+
+import java.util.UUID;
+
+/**
+ * 사용자 도메인 이벤트 발행 인터페이스.
+ *
+ * <p>구현체는 common 라이브러리의 Outbox 패턴({@code Events.trigger(OutboxEvent)})을 사용.
+ * 트랜잭션 커밋 후 Kafka로 발행된다.</p>
+ */
+public interface UserEvents {
+
+    /**
+     * 사용자 변경 이벤트 발행.
+     *
+     * @param user 변경된 사용자
+     * @param updatedBy 변경 주체 (마스터 관리자) — SecurityUtil 미연동 시 null 가능
+     */
+    void userChanged(User user, UUID updatedBy);
+}

--- a/src/main/java/com/loopang/userservice/infrastructure/event/UserEventsImpl.java
+++ b/src/main/java/com/loopang/userservice/infrastructure/event/UserEventsImpl.java
@@ -1,0 +1,47 @@
+package com.loopang.userservice.infrastructure.event;
+
+import com.loopang.common.event.Events;
+import com.loopang.common.event.OutboxEvent;
+import com.loopang.userservice.domain.entity.User;
+import com.loopang.userservice.domain.event.ManagerUpdatedEvent;
+import com.loopang.userservice.domain.event.UserEvents;
+import com.loopang.userservice.infrastructure.kafka.UserTopicProperties;
+import lombok.RequiredArgsConstructor;
+import org.slf4j.MDC;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+
+import java.util.UUID;
+
+/**
+ * {@link UserEvents} 구현 — common 라이브러리의 Outbox 패턴을 사용한다.
+ *
+ * <p>{@code Events.trigger(OutboxEvent)}는 현재 트랜잭션의 영속성 컨텍스트에
+ * Outbox 행을 PENDING으로 저장하고, 트랜잭션 커밋 후 OutboxEventListener가
+ * Kafka로 발행한다.</p>
+ */
+@Component
+@RequiredArgsConstructor
+@EnableConfigurationProperties(UserTopicProperties.class)
+public class UserEventsImpl implements UserEvents {
+
+    private final UserTopicProperties properties;
+
+    @Override
+    public void userChanged(User user, UUID updatedBy) {
+        OutboxEvent event = OutboxEvent.withCorrelation(
+                getTraceId(),
+                "USER",
+                user.getId(),
+                properties.updated(),
+                ManagerUpdatedEvent.from(user, updatedBy)
+        );
+        Events.trigger(event);
+    }
+
+    private String getTraceId() {
+        String traceId = MDC.get("traceId");
+        return StringUtils.hasText(traceId) ? traceId : UUID.randomUUID().toString();
+    }
+}

--- a/src/main/java/com/loopang/userservice/infrastructure/kafka/UserTopicProperties.java
+++ b/src/main/java/com/loopang/userservice/infrastructure/kafka/UserTopicProperties.java
@@ -1,0 +1,14 @@
+package com.loopang.userservice.infrastructure.kafka;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+/**
+ * user 도메인이 발행하는 Kafka 토픽 이름.
+ *
+ * <p>{@code topics.user.updated}는 사용자 변경 시 발행되는 토픽으로,
+ * company-service 등 구독자가 자기 도메인의 사용자/담당자 정보 동기화에 사용한다.</p>
+ */
+@ConfigurationProperties(prefix = "topics.user")
+public record UserTopicProperties(
+        String updated
+) {}

--- a/src/main/java/com/loopang/userservice/presentation/controller/UserController.java
+++ b/src/main/java/com/loopang/userservice/presentation/controller/UserController.java
@@ -73,10 +73,11 @@ public class UserController {
     @PatchMapping("/{userId}")
     public CommonResponse<UserResponseDto> updateUser(
             @PathVariable UUID userId,
+            @RequestHeader("X-User-UUID") UUID requesterId,
             @RequestHeader("X-User-Role") String userRole,
             @Valid @RequestBody UserUpdateRequestDto request) {
         checkMaster(userRole);
-        return CommonResponse.success(userService.updateUser(userId, request), "사용자 정보가 수정되었습니다.");
+        return CommonResponse.success(userService.updateUser(userId, request, requesterId), "사용자 정보가 수정되었습니다.");
     }
 
     @DeleteMapping("/{userId}")

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -9,13 +9,9 @@ spring:
         enabled: true
         service-id: config-server
   kafka:
+    # 현재 user-service는 producer 전용 (Outbox로 user-update-topic 발행).
+    # consumer 설정은 향후 hub.updated 등 구독 추가 시 함께 넣는다.
     bootstrap-servers: ${KAFKA_BOOTSTRAP_SERVERS:localhost:9092}
-    consumer:
-      group-id: user-group
-      auto-offset-reset: earliest
-      enable-auto-commit: false
-    listener:
-      ack-mode: manual
 
 eureka:
   client:

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -8,6 +8,14 @@ spring:
       discovery:
         enabled: true
         service-id: config-server
+  kafka:
+    bootstrap-servers: ${KAFKA_BOOTSTRAP_SERVERS:localhost:9092}
+    consumer:
+      group-id: user-group
+      auto-offset-reset: earliest
+      enable-auto-commit: false
+    listener:
+      ack-mode: manual
 
 eureka:
   client:
@@ -25,3 +33,7 @@ keycloak:
   password: ${KEYCLOAK_PASSWORD:admin}
   client-id: ${KEYCLOAK_CLIENT_ID:loopang-client}
   client-secret: ${KEYCLOAK_CLIENT_SECRET}
+
+topics:
+  user:
+    updated: ${TOPICS_USER_UPDATED:user-update-topic}


### PR DESCRIPTION
## 📌 작업 유형
- [x] 신규 기능 추가

## ✅ 작업 내용

company-service(단비님 PR #5)가 \`user-update-topic\`을 구독하고 있는데 user-service가 발행하지 않아 담당자(manager) 정보 정합성이 깨지는 상황을 해결.

### 신규 파일
- \`infrastructure/kafka/UserTopicProperties\` — \`topics.user.updated\` 설정
- \`domain/event/ManagerUpdatedEvent\` — 단비님 spec 그대로 \`{ managerId, managerName, updatedBy }\`
- \`domain/event/UserEvents\` — 도메인 이벤트 인터페이스
- \`infrastructure/event/UserEventsImpl\` — common Outbox 패턴 사용 (\`Events.trigger\`)

### 변경 파일
- \`application.yaml\` — kafka 설정 + \`topics.user.updated=user-update-topic\` 추가
- \`UserService.updateUser(userId, request, requesterId)\` — 시그니처 변경 + \`userEvents.userChanged()\` 호출
- \`UserController.updateUser\` — \`X-User-UUID\` 헤더 받아 \`requesterId\`로 전달

### 발행 흐름
\`\`\`text
UserService.updateUser() (트랜잭션)
  ├─ user.update(...)
  ├─ userEvents.userChanged(user, requesterId)
  │   └─ Outbox에 PENDING으로 저장
  └─ commit
       └─ OutboxEventListener (AFTER_COMMIT)
            └─ Kafka 발행 → user-update-topic
                 └─ company-service consume → companies 테이블 manager_name 동기화
\`\`\`

### Payload
단비님(company-service)이 정의한 \`ManagerUpdatedEvent\`와 동일 필드명 사용:

\`\`\`java
public record ManagerUpdatedEvent(
    UUID managerId,    // = userId
    String managerName,// = user.name
    UUID updatedBy
) {}
\`\`\`

> user 도메인 관점에선 \`userId\`/\`userName\`이 자연스럽지만, company-service가 이미 manager 용어로 정의해놨으므로 우리가 맞춘다. 협의 비용 최소화.

## 🧪 테스트 / 확인 방법
- [x] 로컬 빌드 성공 (BUILD SUCCESSFUL)
- [ ] 로컬 통합 테스트 (Kafka + company-service 함께 띄워서 확인)
- [ ] 머지 후 단비님께 슬랙 핑

## ⚠️ 영향 범위
- [x] 신규 의존성 — Kafka (common 라이브러리에서 가져옴)
- [x] 컨트롤러 시그니처 변경 (X-User-UUID 헤더 추가)
- [x] application.yaml — kafka 설정 + topic 신규

## 👀 리뷰 포인트
- common 라이브러리의 Outbox 패턴 활용 — \`Events.trigger(OutboxEvent)\` 한 줄로 발행
- \`updatedBy\`는 SecurityUtil 미연동 상태라 \`X-User-UUID\` 헤더로 받아 전달
- 삭제 이벤트는 본 PR 범위 외 (단비님도 추후 협의 예정)
- Kafka 미가동 환경에서 빌드/기동은 정상 동작 (발행만 안 됨, OutboxRelayScheduler가 재시도)

## 🤝 연관 작업
- company-service PR #5: 본 이벤트의 consumer
- hub-service PR #4: 동일 패턴으로 \`hub-update-topic\` 발행 (병행 진행)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 사용자 변경 이벤트 추적 시스템 추가: 사용자 정보 업데이트 시 변경 사항이 이벤트로 발행됩니다.
  * 사용자 업데이트 API에 요청자 식별 헤더 추가: `X-User-UUID` 헤더를 통해 변경을 초래한 사용자를 추적합니다.

* **개선사항**
  * Kafka 기반 이벤트 스트리밍 인프라 구성으로 변경 이력 관리 강화.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->