### PR TITLE
chore: spring-dotenv + Kafka SSL 설정 (GCP 연동)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,27 @@
+# user-service 로컬 환경 변수 템플릿
+# 사용법: 본 파일을 .env로 복사한 뒤 실제 값으로 채워넣는다 (cp .env.example .env)
+# .env 파일은 .gitignore에 등록되어 커밋되지 않는다.
+
+# ─── DB ─────────────────────────────────────────
+DB_URL=localhost:5432/user
+DB_USERNAME=postgres
+DB_PASSWORD=postgres
+
+# ─── Eureka ──────────────────────────────────────
+EUREKA_SERVER_URL=http://localhost:18761/eureka
+
+# ─── Keycloak ────────────────────────────────────
+KEYCLOAK_SERVER_URL=http://localhost:13300
+REALM=my-realm
+KEYCLOAK_USERNAME=admin
+KEYCLOAK_PASSWORD=admin
+KEYCLOAK_CLIENT_ID=loopang-client
+KEYCLOAK_CLIENT_SECRET=
+
+# ─── Kafka (GCP, SSL) ────────────────────────────
+# 브로커 주소는 팀 GCP Kafka 클러스터. 외부 노출 금지.
+BOOTSTRAP_SERVERS=
+TRUST_STORE_PASSWORD=
+
+# ─── Topics (선택) ────────────────────────────────
+# TOPICS_USER_UPDATED=user-update-topic

--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,10 @@ out/
 
 ### VS Code ###
 .vscode/
-.env*
+.env
+!.env.example
 kafka.server.truststore.jks
 ignoredocs/
+
+# Kafka SSL truststore
+src/main/resources/ssl/

--- a/build.gradle
+++ b/build.gradle
@@ -34,6 +34,9 @@ repositories {
 dependencies {
     // 공통 모듈
     implementation 'com.loopang:common:0.0.5-SNAPSHOT'
+
+    // .env 파일 자동 로딩 (로컬 개발용 환경 변수 관리)
+    implementation 'me.paulschwarz:spring-dotenv:4.0.0'
     //keycloak
     implementation 'org.springframework.boot:spring-boot-starter-oauth2-resource-server'
     implementation 'org.keycloak:keycloak-admin-client:24.0.0'

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -9,9 +9,24 @@ spring:
         enabled: true
         service-id: config-server
   kafka:
-    # 현재 user-service는 producer 전용 (Outbox로 user-update-topic 발행).
-    # consumer 설정은 향후 hub.updated 등 구독 추가 시 함께 넣는다.
-    bootstrap-servers: ${KAFKA_BOOTSTRAP_SERVERS:localhost:9092}
+    # producer 전용 (Outbox로 user-update-topic 발행). consumer 설정은 향후 hub.updated 등 구독 추가 시.
+    bootstrap-servers: ${BOOTSTRAP_SERVERS}
+    properties:
+      security.protocol: SSL
+      ssl.endpoint.identification.algorithm: ""
+    ssl:
+      trust-store-location: classpath:ssl/kafka.server.truststore.jks
+      trust-store-password: ${TRUST_STORE_PASSWORD}
+    producer:
+      acks: all
+      key-serializer: org.apache.kafka.common.serialization.StringSerializer
+      value-serializer: org.apache.kafka.common.serialization.StringSerializer
+      properties:
+        enable.idempotence: true
+        max.block.ms: 10000
+        max.in.flight.requests.per.connection: 5
+        retries: 3
+        delivery.timeout.ms: 120000
 
 eureka:
   client:


### PR DESCRIPTION
## 📌 작업 유형
- [x] 환경 설정 / 의존성 추가

## ✅ 작업 내용

### spring-dotenv 도입
- \`build.gradle\`에 \`me.paulschwarz:spring-dotenv:4.0.0\` 추가
- 프로젝트 루트의 \`.env\` 파일을 자동으로 환경변수로 로드
- \`.env\`는 \`.gitignore\`에 등록 → 커밋 안 됨
- \`.env.example\` 추가 — 템플릿 (실제 값 비움, 커밋됨)

### Kafka SSL 설정 (GCP 연동)
팀 GCP Kafka 클러스터(SSL 강제)에 연결하기 위한 설정 추가:

\`\`\`yaml
spring:
  kafka:
    bootstrap-servers: \${BOOTSTRAP_SERVERS}            # 환경변수만, fallback에 IP 노출 X
    properties:
      security.protocol: SSL
      ssl.endpoint.identification.algorithm: ""
    ssl:
      trust-store-location: classpath:ssl/kafka.server.truststore.jks
      trust-store-password: \${TRUST_STORE_PASSWORD}
    producer: ...   # 단비님 가이드 준수
\`\`\`

### gitignore 정리
- \`.env*\` → \`.env\` + \`!.env.example\` (템플릿은 추적 가능하도록 분리)
- \`src/main/resources/ssl/\` 추가 (truststore 노출 방지)

## 🧪 사용법

1. 본 PR 머지 후:
   \`\`\`bash
   cp .env.example .env
   # .env 열어 실제 값 채워넣기
   # truststore 파일은 src/main/resources/ssl/에 직접 복사
   \`\`\`
2. IntelliJ에서 그냥 Run → spring-dotenv가 .env 자동 로드

## ⚠️ 영향 범위
- 의존성 추가 (spring-dotenv)
- application.yaml에 Kafka SSL 설정 추가
- .gitignore 업데이트

## 🤝 연관 작업
- hub-service, route-service에도 동일한 .env 패턴 적용 (각각 별도 PR)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 업데이트 사항

* **새로운 기능**
  * 환경 변수 구성 파일 지원이 추가되었습니다. 데이터베이스, 서비스 디스커버리, 인증 등의 설정이 포함됩니다
  * Kafka 메시징 서비스에 SSL/TLS 보안 프로토콜이 적용되었습니다

* **기타**
  * 환경 변수 관리 라이브러리가 추가되었습니다

<!-- end of auto-generated comment: release notes by coderabbit.ai -->