### PR TITLE
fix: spring-dotenv 명시적 import + Kafka truststore PKCS12 타입 명시

### DIFF
--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -2,7 +2,9 @@ spring:
   application:
     name: user-service
   config:
-    import: 'optional:configserver:'
+    import:
+      - 'optional:dotenv:'
+      - 'optional:configserver:'
   cloud:
     config:
       discovery:
@@ -17,6 +19,7 @@ spring:
     ssl:
       trust-store-location: classpath:ssl/kafka.server.truststore.jks
       trust-store-password: ${TRUST_STORE_PASSWORD}
+      trust-store-type: PKCS12
     producer:
       acks: all
       key-serializer: org.apache.kafka.common.serialization.StringSerializer


### PR DESCRIPTION
## 배경

로컬에서 user-service를 띄울 때 다음 두 가지 이슈로 ApplicationContext 시작이 실패하는 현상이 있었습니다. 둘 다 \`application.yaml\` 한 군데만 손보면 해결되는 환경 설정 fix입니다.

## 변경 내용

### 1. \`spring.config.import\`에 \`optional:dotenv:\` 추가
- spring-dotenv 4.0.0부터는 자동 PropertySource 등록이 빠져서 명시적으로 import 해야 \`.env\`가 로드됩니다.
- 안 하면 \`\${DB_URL}\`, \`\${TRUST_STORE_PASSWORD}\` 등 placeholder가 unresolved 되어 PlaceholderResolutionException 또는 비밀번호 오류로 위장됩니다.

### 2. \`spring.kafka.ssl.trust-store-type: PKCS12\` 추가
- \`kafka.server.truststore.jks\` 파일은 확장자만 \`.jks\`고 실제 형식은 PKCS12입니다 (\`keytool -list\`로 확인).
- 타입 명시 안 하면 Spring Kafka가 JKS로 로드 시도 → "keystore password was incorrect" 에러로 위장됩니다 (실제로는 비밀번호가 아니라 형식 mismatch).

## 검증

hub-service에서 동일한 패턴으로 fix해서 정상 기동을 확인했습니다 (Eureka 등록 + Kafka SSL 핸드쉐이크 + topic partition 할당 + outbox poller). user-service도 동일 코드 패턴이라 같은 fix가 필요합니다.

## 주의사항

이 PR은 application.yaml 변경만 포함합니다. 로컬 환경에서 정상 기동하려면 추가로:
- 모듈 root에 \`.env\` 파일 (\`.env.example\` 참고)
- IntelliJ Run Config에서 Working directory를 \`\$MODULE_WORKING_DIR\$\`로 설정 (멀티모듈 IntelliJ 프로젝트에서 spring-dotenv가 모듈 폴더의 .env를 찾도록)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **구성 업데이트**
  * Spring Cloud Config 구성이 선택적 dotenv를 통한 환경 변수 기반 설정을 지원하도록 개선
  * Kafka 메시징 시스템의 SSL 보안 설정이 추가되어 안전한 통신 환경 지원

<!-- end of auto-generated comment: release notes by coderabbit.ai -->